### PR TITLE
Fix save behavior + cover YApi OpenAPI endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ PORT=3388
 # 多项目Token格式: projectId:token,projectId:token
 YAPI_TOKEN=projectId:your_yapi_token_here,projectId2:your_yapi_token2_here
 
+# 鉴权模式：token 或 global（只配置一次账号密码，启动后调用 yapi_update_token 缓存项目 token）
+YAPI_AUTH_MODE=token
+# 全局模式登录账号（YAPI_AUTH_MODE=global 时使用）
+YAPI_EMAIL=your_email@example.com
+YAPI_PASSWORD=your_password
+
 # 项目基础URL
 YAPI_BASE_URL=your_yapi_base_url_here
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 
 ### 推荐方式：用 Cross Request Master 一键生成 MCP 配置（免手动找 Token）
 
-如果你日常就在浏览器里使用 YApi，推荐安装 Chrome 扩展 [cross-request-master](https://github.com/leeguooooo/cross-request-master)。它会在 YApi 接口详情页（基本信息区域右上角）提供 **「MCP 配置」** 按钮，自动根据当前项目拼好 Cursor / Codex / Gemini CLI / Claude Code 的配置并支持一键复制（包含 `--yapi-base-url`、`--yapi-token=projectId:token` 等参数）。
+如果你日常就在浏览器里使用 YApi，推荐安装 Chrome 扩展 [cross-request-master](https://github.com/leeguooooo/cross-request-master)。它会在 YApi 接口详情页（基本信息区域右上角）提供 **「当前项目 MCP 配置」** / **「整个项目 MCP 配置」** 按钮，可一键生成并复制配置：
+
+- 当前项目：使用 `--yapi-token=projectId:token`
+- 整个项目（全局模式）：使用 `--yapi-auth-mode=global`（账号密码），启动后再调用一次 `yapi_update_token` 自动缓存所有项目 token
 
 ### 手动方式：使用 npx（无需安装）
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 
 ### 推荐方式：用 Cross Request Master 一键生成 MCP 配置（免手动找 Token）
 
-如果你日常就在浏览器里使用 YApi，推荐安装 Chrome 扩展 [cross-request-master](https://github.com/leeguooooo/cross-request-master)。它会在 YApi 接口详情页（基本信息区域右上角）提供 **「当前项目 MCP 配置」** / **「整个项目 MCP 配置」** 按钮，可一键生成并复制配置：
+如果你日常就在浏览器里使用 YApi，推荐安装 Chrome 扩展 [cross-request-master](https://github.com/leeguooooo/cross-request-master)。它会在 YApi 接口详情页（基本信息区域右上角）提供 **「当前项目 MCP 配置」** / **「所有项目 MCP 配置」** 按钮，可一键生成并复制配置：
 
 - 当前项目：使用 `--yapi-token=projectId:token`
 - 整个项目（全局模式）：使用 `--yapi-auth-mode=global`（账号密码），启动后再调用一次 `yapi_update_token` 自动缓存所有项目 token

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 
 - **yapi_search_apis**: 按名称、路径、标签等条件搜索接口
 - **yapi_get_api_desc**: 获取特定接口的详细信息（请求/响应结构、参数等）
+- **yapi_interface_get**: 获取接口原始数据（对应 `/api/interface/get`）
+- **yapi_interface_list**: 获取接口列表（对应 `/api/interface/list`）
+- **yapi_interface_list_cat**: 获取分类下接口列表（对应 `/api/interface/list_cat`）
+- **yapi_interface_list_menu**: 获取接口菜单列表（对应 `/api/interface/list_menu`）
 - **yapi_list_projects**: 列出所有可访问的项目
-- **yapi_get_categories**: 获取项目下的接口分类和接口列表
+- **yapi_project_get**: 获取项目详情（对应 `/api/project/get`）
+- **yapi_get_categories**: 获取项目下的接口分类和接口列表（支持只返回分类/或包含接口列表）
+- **yapi_interface_get_cat_menu**: 获取分类菜单（对应 `/api/interface/getCatMenu`）
 
 ### ✏️ 接口管理
 
@@ -29,6 +35,12 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
   - 支持完整的接口定义（路径、方法、参数、请求体、响应等）
   - 支持 JSON Schema 和表单数据格式
   - 自动处理接口状态和分类管理
+  - 建议把「枚举值/中文备注/示例」优先写在 `req_params` / `req_query` / `req_headers` / `req_body_*` / `res_body`，`desc` 只写一句话简介；更新接口时未提供的字段会尽量保留原值
+- **yapi_interface_add**: 新增接口（对应 `/api/interface/add`）
+- **yapi_interface_up**: 更新接口（对应 `/api/interface/up`）
+- **yapi_interface_save**: 新增或更新接口（对应 `/api/interface/save`）
+- **yapi_interface_add_cat**: 新增接口分类（对应 `/api/interface/add_cat`）
+- **yapi_open_import_data**: 服务端数据导入（对应 `/api/open/import_data`）
 
 ### 🎯 智能特性
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 - **yapi_project_get**: 获取项目详情（对应 `/api/project/get`）
 - **yapi_get_categories**: 获取项目下的接口分类和接口列表（支持只返回分类/或包含接口列表）
 - **yapi_interface_get_cat_menu**: 获取分类菜单（对应 `/api/interface/getCatMenu`）
+- **yapi_update_token**: 全局模式登录并刷新本地项目 token 缓存（只需配置一次账号密码）
 
 ### ✏️ 接口管理
 
@@ -57,8 +58,9 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 
 ### 手动方式：使用 npx（无需安装）
 
-1. **获取 YApi Token**：登录你的 YApi 平台，在项目设置中获取 Token
-2. **配置 Cursor**：在 Cursor 设置中添加 MCP 服务器：
+你可以选择两种模式：
+
+1) **项目 Token 模式**（与 Cross Request Master 的一键配置一致）
 
 ```json
 {
@@ -77,7 +79,28 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 }
 ```
 
-3. **开始使用**：重启 Cursor，你就可以在对话中直接操作 YApi 了！
+2) **全局模式**（只配置一次账号密码，项目 token 自动本地缓存）
+
+```json
+{
+  "mcpServers": {
+    "yapi-auto-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "yapi-auto-mcp",
+        "--stdio",
+        "--yapi-base-url=https://your-yapi-domain.com",
+        "--yapi-auth-mode=global",
+        "--yapi-email=your_email@example.com",
+        "--yapi-password=your_password"
+      ]
+    }
+  }
+}
+```
+
+启动后先在对话里调用一次 `yapi_update_token`，会把 `projectId -> token` 缓存到本地 `~/.yapi-mcp/auth-*.json`，后续所有工具就都能直接使用了。
 
 ## 安装配置
 
@@ -121,8 +144,28 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
       "env": {
         "YAPI_BASE_URL": "https://yapi.example.com",
         "YAPI_TOKEN": "projectId:token1,projectId2:token2",
+        "YAPI_AUTH_MODE": "token",
         "YAPI_CACHE_TTL": "10",
         "YAPI_LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+全局模式对应环境变量（更适合“只配置一次”）：
+
+```json
+{
+  "mcpServers": {
+    "yapi-auto-mcp": {
+      "command": "npx",
+      "args": ["-y", "yapi-auto-mcp", "--stdio"],
+      "env": {
+        "YAPI_BASE_URL": "https://yapi.example.com",
+        "YAPI_AUTH_MODE": "global",
+        "YAPI_EMAIL": "your_email@example.com",
+        "YAPI_PASSWORD": "your_password"
       }
     }
   }
@@ -187,6 +230,8 @@ node dist/cli.js --stdio
 
 ### 获取 YApi Token
 
+如果你使用的是 **全局模式**（`--yapi-auth-mode=global` / `YAPI_AUTH_MODE=global`），可以不手动找项目 token：启动后在对话里调用一次 `yapi_update_token`，会自动登录并把所有可访问项目的 `projectId -> token` 缓存到本地。
+
 1. 登录你的 YApi 平台
 2. 进入项目设置页面
 3. 在 Token 配置中生成或查看 Token
@@ -231,6 +276,9 @@ Token 格式说明：
 | ------------------ | ----------------------------- | ------------------------------------------ | ------ |
 | `--yapi-base-url`  | YApi 服务器基础 URL           | `--yapi-base-url=https://yapi.example.com` | -      |
 | `--yapi-token`     | YApi 项目 Token（支持多项目） | `--yapi-token=1026:token1,1027:token2`     | -      |
+| `--yapi-auth-mode` | 鉴权模式：`token` 或 `global` | `--yapi-auth-mode=global`                  | token  |
+| `--yapi-email`     | 全局模式登录邮箱              | `--yapi-email=a@b.com`                     | -      |
+| `--yapi-password`  | 全局模式登录密码              | `--yapi-password=******`                   | -      |
 | `--yapi-cache-ttl` | 缓存时效（分钟）              | `--yapi-cache-ttl=10`                      | 10     |
 | `--yapi-log-level` | 日志级别                      | `--yapi-log-level=info`                    | info   |
 | `--port`           | HTTP 服务端口（SSE 模式）     | `--port=3388`                              | 3388   |
@@ -243,7 +291,15 @@ Token 格式说明：
 ```env
 # 必需配置
 YAPI_BASE_URL=https://your-yapi-domain.com
+
+# 模式一：项目 Token 模式
+YAPI_AUTH_MODE=token
 YAPI_TOKEN=projectId:your_token_here
+
+# 模式二：全局模式（只配置一次账号密码，启动后调用 yapi_update_token 缓存项目 token）
+# YAPI_AUTH_MODE=global
+# YAPI_EMAIL=your_email@example.com
+# YAPI_PASSWORD=your_password
 
 # 可选配置
 PORT=3388                    # HTTP 服务端口

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 
 启动后先在对话里调用一次 `yapi_update_token`，会把 `projectId -> token` 缓存到本地 `~/.yapi-mcp/auth-*.json`。部分 YApi 部署不会在开放 API 中直接返回 token，本项目会自动兜底从项目设置页抓取 token。
 
+提示：stdio 模式下为了加快 MCP 启动（避免超时），本项目不会在启动阶段做任何“全量缓存预热请求”。如需更快的工具响应，建议先调用一次 `yapi_update_token`。
+
 ## 安装配置
 
 ### 方式一：npx 直接使用（推荐）

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 如果你日常就在浏览器里使用 YApi，推荐安装 Chrome 扩展 [cross-request-master](https://github.com/leeguooooo/cross-request-master)。它会在 YApi 接口详情页（基本信息区域右上角）提供 **「当前项目 MCP 配置」** / **「所有项目 MCP 配置」** 按钮，可一键生成并复制配置：
 
 - 当前项目：使用 `--yapi-token=projectId:token`
-- 整个项目（全局模式）：使用 `--yapi-auth-mode=global`（账号密码），启动后再调用一次 `yapi_update_token` 自动缓存所有项目 token
+- 所有项目（全局模式）：使用 `--yapi-auth-mode=global`（账号密码），启动后再调用一次 `yapi_update_token` 自动缓存所有项目 token
 
 ### 手动方式：使用 npx（无需安装）
 
@@ -103,7 +103,7 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 }
 ```
 
-启动后先在对话里调用一次 `yapi_update_token`，会把 `projectId -> token` 缓存到本地 `~/.yapi-mcp/auth-*.json`，后续所有工具就都能直接使用了。
+启动后先在对话里调用一次 `yapi_update_token`，会把 `projectId -> token` 缓存到本地 `~/.yapi-mcp/auth-*.json`。部分 YApi 部署不会在开放 API 中直接返回 token，本项目会自动兜底从项目设置页抓取 token。
 
 ## 安装配置
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Yapi Auto MCP Server 是一个基于 [Model Context Protocol](https://modelconte
 
 ## 快速开始
 
-### 推荐方式：使用 npx（无需安装）
+### 推荐方式：用 Cross Request Master 一键生成 MCP 配置（免手动找 Token）
+
+如果你日常就在浏览器里使用 YApi，推荐安装 Chrome 扩展 [cross-request-master](https://github.com/leeguooooo/cross-request-master)。它会在 YApi 接口详情页（基本信息区域右上角）提供 **「MCP 配置」** 按钮，自动根据当前项目拼好 Cursor / Codex / Gemini CLI / Claude Code 的配置并支持一键复制（包含 `--yapi-base-url`、`--yapi-token=projectId:token` 等参数）。
+
+### 手动方式：使用 npx（无需安装）
 
 1. **获取 YApi Token**：登录你的 YApi 平台，在项目设置中获取 Token
 2. **配置 Cursor**：在 Cursor 设置中添加 MCP 服务器：
@@ -186,6 +190,8 @@ node dist/cli.js --stdio
 1. 登录你的 YApi 平台
 2. 进入项目设置页面
 3. 在 Token 配置中生成或查看 Token
+
+不想手动找 Token 的话，可以用 [cross-request-master](https://github.com/leeguooooo/cross-request-master) 在接口详情页一键生成 MCP 配置（会自动带上 `projectId:token`）。
 
 ![Token 获取示例](./images/token.png)
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start:http": "node dist/index.js",
     "dev": "cross-env NODE_ENV=development tsx watch src/index.ts",
     "dev:cli": "cross-env NODE_ENV=development tsx watch src/index.ts --stdio",
+    "smoke:global": "pnpm build && tsx scripts/smoke-global.ts",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "inspect": "pnpx @modelcontextprotocol/inspector",

--- a/scripts/smoke-global.ts
+++ b/scripts/smoke-global.ts
@@ -1,0 +1,99 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+function getArgValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  }
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx >= 0) return process.argv[idx + 1];
+  return undefined;
+}
+
+function requireEnv(key: string): string {
+  const v = process.env[key];
+  if (!v) throw new Error(`Missing env ${key}`);
+  return v;
+}
+
+function toEnvRecord(env: NodeJS.ProcessEnv): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+function toText(result: any): string {
+  const parts = result?.content;
+  if (!Array.isArray(parts)) return JSON.stringify(result, null, 2);
+  return parts
+    .map((p: any) => {
+      if (p?.type === "text") return String(p.text || "");
+      return JSON.stringify(p);
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+async function main() {
+  const baseUrl = (process.env.YAPI_BASE_URL || getArgValue("yapi-base-url") || "").replace(/\/+$/, "");
+  if (!baseUrl) throw new Error("Missing YAPI_BASE_URL (or --yapi-base-url)");
+  const email = process.env.YAPI_EMAIL || getArgValue("yapi-email") || "";
+  const password = process.env.YAPI_PASSWORD || getArgValue("yapi-password") || "";
+  if (!email) throw new Error("Missing YAPI_EMAIL (or --yapi-email)");
+  if (!password) throw new Error("Missing YAPI_PASSWORD (or --yapi-password)");
+
+  const projectId = getArgValue("project-id") || process.env.YAPI_SMOKE_PROJECT_ID || "";
+  const forceLogin = (getArgValue("force-login") || "").toLowerCase() === "true";
+
+  const env = {
+    ...toEnvRecord(process.env),
+    YAPI_BASE_URL: baseUrl,
+    YAPI_AUTH_MODE: "global",
+    YAPI_EMAIL: email,
+    YAPI_PASSWORD: password,
+    YAPI_LOG_LEVEL: process.env.YAPI_LOG_LEVEL || "debug",
+  };
+
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: ["dist/index.js", "--stdio"],
+    env,
+    stderr: "inherit",
+  });
+
+  const client = new Client(
+    { name: "yapi-mcp-smoke", version: "0.0.0" },
+    { capabilities: { tools: {}, prompts: {}, resources: {} } },
+  );
+
+  await client.connect(transport);
+  try {
+    const tools = await client.listTools();
+    console.log(`[smoke] tools: ${tools.tools?.length ?? 0}`);
+
+    const update = await client.callTool({
+      name: "yapi_update_token",
+      arguments: { forceLogin },
+    });
+    console.log("[smoke] yapi_update_token:\n" + toText(update));
+
+    const list = await client.callTool({ name: "yapi_list_projects", arguments: {} });
+    console.log("[smoke] yapi_list_projects:\n" + toText(list));
+
+    if (projectId) {
+      const proj = await client.callTool({ name: "yapi_project_get", arguments: { projectId } });
+      console.log(`[smoke] yapi_project_get(${projectId}):\n` + toText(proj));
+    }
+  } finally {
+    await transport.close().catch(() => undefined);
+  }
+}
+
+main().catch((e) => {
+  console.error("[smoke] failed:", e?.message || e);
+  process.exit(1);
+});
+

--- a/scripts/smoke-global.ts
+++ b/scripts/smoke-global.ts
@@ -47,6 +47,9 @@ async function main() {
 
   const projectId = getArgValue("project-id") || process.env.YAPI_SMOKE_PROJECT_ID || "";
   const forceLogin = (getArgValue("force-login") || "").toLowerCase() === "true";
+  const searchProjectKeyword = getArgValue("search-project-keyword") || "";
+  const searchNameKeyword = getArgValue("search-name-keyword") || "";
+  const searchPathKeyword = getArgValue("search-path-keyword") || "";
 
   const env = {
     ...toEnvRecord(process.env),
@@ -83,6 +86,19 @@ async function main() {
     const list = await client.callTool({ name: "yapi_list_projects", arguments: {} });
     console.log("[smoke] yapi_list_projects:\n" + toText(list));
 
+    if (searchProjectKeyword || searchNameKeyword || searchPathKeyword) {
+      const search = await client.callTool({
+        name: "yapi_search_apis",
+        arguments: {
+          projectKeyword: searchProjectKeyword || undefined,
+          nameKeyword: searchNameKeyword || undefined,
+          pathKeyword: searchPathKeyword || undefined,
+          limit: 50,
+        },
+      });
+      console.log("[smoke] yapi_search_apis:\n" + toText(search));
+    }
+
     if (projectId) {
       const proj = await client.callTool({ name: "yapi_project_get", arguments: { projectId } });
       console.log(`[smoke] yapi_project_get(${projectId}):\n` + toText(proj));
@@ -96,4 +112,3 @@ main().catch((e) => {
   console.error("[smoke] failed:", e?.message || e);
   process.exit(1);
 });
-

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,12 +9,18 @@ config();
 interface ServerConfig {
   yapiBaseUrl: string;
   yapiToken: string;
+  yapiAuthMode: "token" | "global";
+  yapiEmail: string;
+  yapiPassword: string;
   port: number;
   yapiCacheTTL: number; // 缓存时效，单位为分钟
   yapiLogLevel: string; // 日志级别：debug, info, warn, error
   configSources: {
     yapiBaseUrl: "cli" | "env" | "default";
     yapiToken: "cli" | "env" | "default";
+    yapiAuthMode: "cli" | "env" | "default";
+    yapiEmail: "cli" | "env" | "default";
+    yapiPassword: "cli" | "env" | "default";
     port: "cli" | "env" | "default";
     yapiCacheTTL: "cli" | "env" | "default";
     yapiLogLevel: "cli" | "env" | "default";
@@ -26,9 +32,18 @@ function maskApiKey(key: string): string {
   return `****${key.slice(-4)}`;
 }
 
+function maskSecret(value: string): string {
+  if (!value) return "";
+  if (value.length <= 2) return "**";
+  return `${value[0]}***${value[value.length - 1]}`;
+}
+
 interface CliArgs {
   "yapi-base-url"?: string;
   "yapi-token"?: string;
+  "yapi-auth-mode"?: "token" | "global";
+  "yapi-email"?: string;
+  "yapi-password"?: string;
   port?: number;
   "yapi-cache-ttl"?: number;
   "yapi-log-level"?: string;
@@ -45,6 +60,19 @@ export function getServerConfig(): ServerConfig {
       "yapi-token": {
         type: "string",
         description: "YApi服务器授权Token",
+      },
+      "yapi-auth-mode": {
+        type: "string",
+        description: "鉴权模式：token=项目 token；global=用户名/密码登录并缓存项目 token",
+        choices: ["token", "global"],
+      },
+      "yapi-email": {
+        type: "string",
+        description: "全局模式登录邮箱（/api/user/login 的 email 字段）",
+      },
+      "yapi-password": {
+        type: "string",
+        description: "全局模式登录密码（/api/user/login 的 password 字段）",
       },
       port: {
         type: "number",
@@ -66,12 +94,18 @@ export function getServerConfig(): ServerConfig {
   const config: ServerConfig = {
     yapiBaseUrl: "http://localhost:3000",
     yapiToken: "",
+    yapiAuthMode: "token",
+    yapiEmail: "",
+    yapiPassword: "",
     port: 3388,
     yapiCacheTTL: 10, // 默认缓存10分钟
     yapiLogLevel: "info", // 默认日志级别
     configSources: {
       yapiBaseUrl: "default",
       yapiToken: "default",
+      yapiAuthMode: "default",
+      yapiEmail: "default",
+      yapiPassword: "default",
       port: "default",
       yapiCacheTTL: "default",
       yapiLogLevel: "default",
@@ -95,6 +129,38 @@ export function getServerConfig(): ServerConfig {
   } else if (process.env.YAPI_TOKEN) {
     config.yapiToken = process.env.YAPI_TOKEN;
     config.configSources.yapiToken = "env";
+  }
+
+  // Handle YAPI_EMAIL / YAPI_PASSWORD (global mode)
+  if (argv["yapi-email"]) {
+    config.yapiEmail = argv["yapi-email"];
+    config.configSources.yapiEmail = "cli";
+  } else if (process.env.YAPI_EMAIL) {
+    config.yapiEmail = process.env.YAPI_EMAIL;
+    config.configSources.yapiEmail = "env";
+  }
+
+  if (argv["yapi-password"]) {
+    config.yapiPassword = argv["yapi-password"];
+    config.configSources.yapiPassword = "cli";
+  } else if (process.env.YAPI_PASSWORD) {
+    config.yapiPassword = process.env.YAPI_PASSWORD;
+    config.configSources.yapiPassword = "env";
+  }
+
+  // Handle YAPI_AUTH_MODE
+  if (argv["yapi-auth-mode"]) {
+    config.yapiAuthMode = argv["yapi-auth-mode"];
+    config.configSources.yapiAuthMode = "cli";
+  } else if (process.env.YAPI_AUTH_MODE) {
+    const mode = process.env.YAPI_AUTH_MODE.toLowerCase();
+    if (mode === "token" || mode === "global") {
+      config.yapiAuthMode = mode;
+      config.configSources.yapiAuthMode = "env";
+    }
+  } else {
+    // default: token 优先；未配置 token 且提供了账号密码则自动切到 global
+    config.yapiAuthMode = config.yapiToken ? "token" : config.yapiEmail && config.yapiPassword ? "global" : "token";
   }
 
   // Handle PORT
@@ -141,6 +207,11 @@ export function getServerConfig(): ServerConfig {
   );
   logger.info(
     `- YAPI_TOKEN: ${config.yapiToken ? maskApiKey(config.yapiToken) : "未配置"} (source: ${config.configSources.yapiToken})`,
+  );
+  logger.info(`- YAPI_AUTH_MODE: ${config.yapiAuthMode} (source: ${config.configSources.yapiAuthMode})`);
+  logger.info(`- YAPI_EMAIL: ${config.yapiEmail || "未配置"} (source: ${config.configSources.yapiEmail})`);
+  logger.info(
+    `- YAPI_PASSWORD: ${config.yapiPassword ? maskSecret(config.yapiPassword) : "未配置"} (source: ${config.configSources.yapiPassword})`,
   );
   logger.info(`- PORT: ${config.port} (source: ${config.configSources.port})`);
   logger.info(`- YAPI_CACHE_TTL: ${config.yapiCacheTTL} 分钟 (source: ${config.configSources.yapiCacheTTL})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,12 @@ export async function startServer(): Promise<void> {
     config.yapiBaseUrl, 
     config.yapiToken, 
     config.yapiLogLevel, 
-    config.yapiCacheTTL
+    config.yapiCacheTTL,
+    {
+      mode: config.yapiAuthMode,
+      email: config.yapiEmail,
+      password: config.yapiPassword,
+    },
   );
 
   // Check if we're running in stdio mode (e.g., via CLI)
@@ -41,6 +46,7 @@ export async function startServer(): Promise<void> {
   logger.info("- yapi_search_apis: 搜索YApi接口");
   logger.info("- yapi_list_projects: 列出YApi的项目ID和项目名称");
   logger.info("- yapi_get_categories: 获取YApi项目下的接口分类列表");
+  logger.info("- yapi_update_token: 全局模式登录并刷新本地 token 缓存");
 }
 
 // If this file is being run directly, start the server

--- a/src/server.ts
+++ b/src/server.ts
@@ -106,7 +106,25 @@ export class YapiMcpServer {
     });
 
     this.registerTools();
-    this.initializeCache();
+    // stdio 模式下 MCP client 需要快速完成握手；不要在启动阶段做任何网络请求/全量缓存预热
+    if (this.isStdioMode) {
+      this.loadCacheFromDiskOnly();
+    } else {
+      this.initializeCache();
+    }
+  }
+
+  private loadCacheFromDiskOnly(): void {
+    try {
+      const cachedProjectInfo = this.projectInfoCache.loadFromCache();
+      if (cachedProjectInfo.size === 0) return;
+      cachedProjectInfo.forEach((info, id) => {
+        this.yapiService.getProjectInfoCache().set(id, info);
+      });
+      this.logger.info(`stdio 模式：已从缓存加载 ${cachedProjectInfo.size} 个项目信息（未做预热请求）`);
+    } catch (e) {
+      this.logger.warn(`stdio 模式：读取缓存失败（忽略）：${e}`);
+    }
   }
 
   private async initializeCache(): Promise<void> {
@@ -116,9 +134,11 @@ export class YapiMcpServer {
         this.logger.info('缓存已过期，将异步更新缓存数据');
 
         // 异步加载最新的项目信息，不阻塞初始化过程
-        this.asyncUpdateCache().catch(error => {
-          this.logger.error('异步更新缓存失败:', error);
-        });
+        setTimeout(() => {
+          this.asyncUpdateCache().catch(error => {
+            this.logger.error('异步更新缓存失败:', error);
+          });
+        }, 0);
       } else {
         // 从缓存加载数据
         const cachedProjectInfo = this.projectInfoCache.loadFromCache();
@@ -134,18 +154,22 @@ export class YapiMcpServer {
         } else {
           // 缓存为空，异步更新
           this.logger.info('缓存为空，将异步更新缓存数据');
-          this.asyncUpdateCache().catch(error => {
-            this.logger.error('异步更新缓存失败:', error);
-          });
+          setTimeout(() => {
+            this.asyncUpdateCache().catch(error => {
+              this.logger.error('异步更新缓存失败:', error);
+            });
+          }, 0);
         }
       }
     } catch (error) {
       this.logger.error('加载或检查缓存时出错:', error);
 
       // 出错时也尝试异步更新缓存
-      this.asyncUpdateCache().catch(err => {
-        this.logger.error('异步更新缓存失败:', err);
-      });
+      setTimeout(() => {
+        this.asyncUpdateCache().catch(err => {
+          this.logger.error('异步更新缓存失败:', err);
+        });
+      }, 0);
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -363,6 +363,8 @@ export class YapiMcpServer {
           const apiInterface = await this.yapiService.getApiInterface(projectId, apiId);
           this.logger.info(`成功获取API接口: ${apiInterface.title || apiId}`);
 
+          const webUrl = this.yapiService.buildInterfaceWebUrl(projectId, apiId);
+
           // 格式化返回数据，使其更易于阅读
           const formattedResponse = {
             基本信息: {
@@ -370,7 +372,8 @@ export class YapiMcpServer {
               接口名称: apiInterface.title,
               接口路径: apiInterface.path,
               请求方式: apiInterface.method,
-              接口描述: apiInterface.desc
+              接口描述: apiInterface.desc,
+              接口页面: webUrl
             },
             请求参数: {
               URL参数: apiInterface.req_params,
@@ -854,6 +857,7 @@ export class YapiMcpServer {
 
           // 按项目分组整理结果
           const apisByProject: Record<string, {
+            projectId: string,
             projectName: string,
             apis: Array<{
               id: string,
@@ -862,7 +866,8 @@ export class YapiMcpServer {
               method: string,
               catName: string,
               createTime: string,
-              updateTime: string
+              updateTime: string,
+              webUrl: string
             }>
           }> = {};
 
@@ -873,6 +878,7 @@ export class YapiMcpServer {
 
             if (!apisByProject[projectId]) {
               apisByProject[projectId] = {
+                projectId,
                 projectName,
                 apis: []
               };
@@ -885,7 +891,8 @@ export class YapiMcpServer {
               method: api.method,
               catName: api.cat_name || '未知分类',
               createTime: new Date(api.add_time).toLocaleString(),
-              updateTime: new Date(api.up_time).toLocaleString()
+              updateTime: new Date(api.up_time).toLocaleString(),
+              webUrl: this.yapiService.buildInterfaceWebUrl(projectId, api._id)
             });
           });
 
@@ -909,15 +916,16 @@ export class YapiMcpServer {
                 responseContent += `### ${api.title} (${api.method} ${api.path})\n\n`;
                 responseContent += `- 接口ID: ${api.id}\n`;
                 responseContent += `- 所属分类: ${api.catName}\n`;
+                responseContent += `- 接口页面: ${api.webUrl}\n`;
                 responseContent += `- 更新时间: ${api.updateTime}\n\n`;
               });
             } else {
               // 大量接口，展示简洁表格
-              responseContent += "| 接口ID | 接口名称 | 请求方式 | 接口路径 | 所属分类 |\n";
-              responseContent += "| ------ | -------- | -------- | -------- | -------- |\n";
+              responseContent += "| 接口ID | 接口名称 | 请求方式 | 接口路径 | 所属分类 | YApi 页面 |\n";
+              responseContent += "| ------ | -------- | -------- | -------- | -------- | -------- |\n";
 
               projectGroup.apis.forEach(api => {
-                responseContent += `| ${api.id} | ${api.title} | ${api.method} | ${api.path} | ${api.catName} |\n`;
+                responseContent += `| ${api.id} | ${api.title} | ${api.method} | ${api.path} | ${api.catName} | ${api.webUrl} |\n`;
               });
 
               responseContent += "\n";
@@ -925,7 +933,7 @@ export class YapiMcpServer {
           });
 
           // 添加使用提示
-          responseContent += "\n提示: 可以使用 `get_api_desc` 工具获取接口的详细信息，例如: `get_api_desc projectId=228 apiId=8570`";
+          responseContent += "\n提示: 可以使用 `yapi_get_api_desc` 工具获取接口的详细信息，例如: `yapi_get_api_desc projectId=232 apiId=12961`";
 
           return {
             content: [{ type: "text", text: responseContent }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { YApiService } from "./services/yapi/api";
 import { ProjectInfoCache } from "./services/yapi/cache";
 import { Logger } from "./services/yapi/logger";
+import { YApiAuthService } from "./services/yapi/auth";
 
 type JsonLike = unknown;
 
@@ -61,13 +62,33 @@ export class YapiMcpServer {
   private readonly yapiService: YApiService;
   private readonly projectInfoCache: ProjectInfoCache;
   private readonly logger: Logger;
+  private readonly authService: YApiAuthService | null;
+  private readonly authMode: "token" | "global";
   private sseTransport: SSEServerTransport | null = null;
   private readonly isStdioMode: boolean;
 
-  constructor(yapiBaseUrl: string, yapiToken: string, yapiLogLevel: string = "info", yapiCacheTTL: number = 10) {
+  constructor(
+    yapiBaseUrl: string,
+    yapiToken: string,
+    yapiLogLevel: string = "info",
+    yapiCacheTTL: number = 10,
+    auth?: { mode?: "token" | "global"; email?: string; password?: string },
+  ) {
     this.logger = new Logger("YapiMCP", yapiLogLevel);
     this.yapiService = new YApiService(yapiBaseUrl, yapiToken, yapiLogLevel);
     this.projectInfoCache = new ProjectInfoCache(yapiCacheTTL);
+    this.authMode = auth?.mode ?? (auth?.email && auth?.password ? "global" : "token");
+    this.authService =
+      this.authMode === "global" && auth?.email && auth?.password
+        ? new YApiAuthService(yapiBaseUrl, auth.email, auth.password, yapiLogLevel)
+        : null;
+
+    if (this.authService) {
+      // 尝试从全局缓存恢复项目 token，避免每次都需要手动刷新
+      const cachedTokens = this.authService.loadCachedProjectTokens();
+      this.yapiService.setProjectTokens(cachedTokens, { overwrite: false });
+      this.logger.info(`全局模式已启用：已从本地缓存加载 ${cachedTokens.size} 个项目 token`);
+    }
     // 判断是否为stdio模式
     this.isStdioMode = process.env.NODE_ENV === "cli" || process.argv.includes("--stdio");
     
@@ -272,6 +293,50 @@ export class YapiMcpServer {
 
       return { ok: true, params, isUpdate };
     };
+
+    // 全局模式：登录并刷新本地项目 token 缓存
+    this.server.tool(
+      "yapi_update_token",
+      "全局模式：使用用户名/密码登录 YApi，刷新本地缓存的 projectId -> token（用于后续调用开放 API）",
+      {
+        forceLogin: z.boolean().optional().describe("是否强制重新登录（忽略已缓存的 cookie）"),
+      },
+      async ({ forceLogin }) => {
+        try {
+          if (!this.authService) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text:
+                    "未启用全局模式：请在 MCP 配置中提供 --yapi-auth-mode=global 以及 --yapi-email/--yapi-password（或对应环境变量），然后再调用 yapi_update_token。",
+                },
+              ],
+            };
+          }
+
+          const { tokens, groups, projects } = await this.authService.refreshProjectTokens({ forceLogin });
+          this.yapiService.setProjectTokens(tokens, { overwrite: true });
+
+          // 刷新项目信息/分类缓存（可选，但有助于 list/search）
+          await this.yapiService.loadAllProjectInfo();
+          this.projectInfoCache.saveToCache(this.yapiService.getProjectInfoCache());
+          await this.yapiService.loadAllCategoryLists();
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: `token 刷新完成：分组 ${groups.length} 个，项目 ${projects.length} 个，已缓存 token ${tokens.size} 个。`,
+              },
+            ],
+          };
+        } catch (error) {
+          this.logger.error("刷新 token 失败:", error);
+          return { content: [{ type: "text", text: `刷新 token 失败: ${error}` }] };
+        }
+      },
+    );
 
     // 获取API接口详情
     this.server.tool(

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,12 @@ export class YapiMcpServer {
       const cachedTokens = this.authService.loadCachedProjectTokens();
       this.yapiService.setProjectTokens(cachedTokens, { overwrite: false });
       this.logger.info(`全局模式已启用：已从本地缓存加载 ${cachedTokens.size} 个项目 token`);
+
+      const cachedCookie = this.authService.getCachedCookieHeader();
+      if (cachedCookie) {
+        this.yapiService.setCookieHeader(cachedCookie);
+        this.logger.info("全局模式已启用：已从本地缓存加载登录态 cookie");
+      }
     }
     // 判断是否为stdio模式
     this.isStdioMode = process.env.NODE_ENV === "cli" || process.argv.includes("--stdio");
@@ -315,8 +321,9 @@ export class YapiMcpServer {
             };
           }
 
-          const { tokens, groups, projects } = await this.authService.refreshProjectTokens({ forceLogin });
+          const { tokens, groups, projects, cookieHeader } = await this.authService.refreshProjectTokens({ forceLogin });
           this.yapiService.setProjectTokens(tokens, { overwrite: true });
+          this.yapiService.setCookieHeader(cookieHeader);
 
           // 刷新项目信息/分类缓存（可选，但有助于 list/search）
           await this.yapiService.loadAllProjectInfo();
@@ -327,7 +334,11 @@ export class YapiMcpServer {
             content: [
               {
                 type: "text",
-                text: `token 刷新完成：分组 ${groups.length} 个，项目 ${projects.length} 个，已缓存 token ${tokens.size} 个。`,
+                text: `token 刷新完成：分组 ${groups.length} 个，项目 ${projects.length} 个，已缓存 token ${tokens.size} 个。${
+                  tokens.size === 0
+                    ? "（提示：部分 YApi 部署不会在开放 API 返回 token，本工具已尝试从项目设置页抓取；如仍为 0，可能账号权限不足或实例限制展示 token。）"
+                    : ""
+                }`,
               },
             ],
           };
@@ -925,6 +936,36 @@ export class YapiMcpServer {
       {},
       async () => {
         try {
+          if (this.authService) {
+            const { projects } = await this.authService.listAccessibleProjects();
+            if (!projects.length) {
+              return {
+                content: [{ type: "text", text: "没有找到任何项目信息，请确认已登录且账号有权限访问项目" }],
+              };
+            }
+
+            const projectsList = projects.map(p => {
+              const id = String(p?._id ?? p?.id ?? "");
+              return {
+                项目ID: id,
+                项目名称: p?.name || p?.project_name || p?.title || "",
+                项目描述: p?.desc || "无描述",
+                基础路径: p?.basepath || "/",
+                项目分组ID: p?.group_id ?? p?.groupId ?? "",
+                已缓存Token: id ? (this.yapiService.hasProjectToken(id) ? "是" : "否") : "否",
+              };
+            });
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `已发现 ${projectsList.length} 个可访问项目（全局模式）:\n\n${JSON.stringify(projectsList, null, 2)}`,
+                },
+              ],
+            };
+          }
+
           // 获取项目信息缓存
           const projectInfoCache = this.yapiService.getProjectInfoCache();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -424,6 +424,24 @@ export class YapiMcpServer {
       },
     );
 
+    // 搜索项目（/api/project/search）
+    this.server.tool(
+      "yapi_project_search",
+      "搜索项目（对应 /api/project/search）",
+      {
+        q: z.string().describe("搜索关键字"),
+      },
+      async ({ q }) => {
+        try {
+          const data = await this.yapiService.globalSearch(q);
+          return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`搜索项目失败:`, error);
+          return { content: [{ type: "text", text: `搜索项目失败: ${error}` }] };
+        }
+      },
+    );
+
     // 获取接口数据（/api/interface/get）
     this.server.tool(
       "yapi_interface_get",

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,53 @@ import { YApiService } from "./services/yapi/api";
 import { ProjectInfoCache } from "./services/yapi/cache";
 import { Logger } from "./services/yapi/logger";
 
+type JsonLike = unknown;
+
+function normalizeJsonArrayInput(value: JsonLike, fieldName: string): { ok: true; value: any[] } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: [] };
+  if (Array.isArray(value)) return { ok: true, value };
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (!Array.isArray(parsed)) return { ok: false, error: `${fieldName} 需要是 JSON 数组` };
+      return { ok: true, value: parsed };
+    } catch (e) {
+      return { ok: false, error: `${fieldName} JSON 解析错误: ${e}` };
+    }
+  }
+  return { ok: false, error: `${fieldName} 需要是 JSON 数组或数组类型` };
+}
+
+function normalizeStringOrJson(value: JsonLike, fieldName: string): { ok: true; value: string } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: "" };
+  if (typeof value === "string") return { ok: true, value };
+  try {
+    return { ok: true, value: JSON.stringify(value, null, 2) };
+  } catch (e) {
+    return { ok: false, error: `${fieldName} 无法序列化为 JSON 字符串: ${e}` };
+  }
+}
+
+function normalizeTagInput(value: JsonLike): { ok: true; value: string[] } | { ok: false; error: string } {
+  if (value === undefined || value === null) return { ok: true, value: [] };
+  if (Array.isArray(value)) return { ok: true, value: value.map(String).filter(Boolean) };
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return { ok: true, value: [] };
+    if (trimmed.startsWith("[")) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (!Array.isArray(parsed)) return { ok: false, error: "tag 需要是 JSON 数组" };
+        return { ok: true, value: parsed.map(String).filter(Boolean) };
+      } catch (e) {
+        return { ok: false, error: `tag JSON 解析错误: ${e}` };
+      }
+    }
+    return { ok: true, value: trimmed.split(/[\s,]+/).map(s => s.trim()).filter(Boolean) };
+  }
+  return { ok: false, error: "tag 需要是字符串或字符串数组" };
+}
+
 export class YapiMcpServer {
   private readonly server: McpServer;
   private readonly yapiService: YApiService;
@@ -102,6 +149,130 @@ export class YapiMcpServer {
   }
 
   private registerTools(): void {
+    const yapiParamItemSchema = z
+      .object({
+        name: z.string().describe("参数名"),
+        desc: z.string().optional().describe("中文备注/说明（建议把枚举、单位、范围等写清楚）"),
+        type: z.string().optional().describe("类型，如 string/number/boolean/integer/object/array"),
+        example: z.string().optional().describe("示例值"),
+        required: z.union([z.string(), z.number(), z.boolean()]).optional().describe("是否必填（YApi 常用 '1'/'0'）"),
+      })
+      .passthrough();
+
+    const yapiHeaderItemSchema = yapiParamItemSchema
+      .extend({
+        value: z.string().optional().describe("Header 值（如 application/json）"),
+      })
+      .passthrough();
+
+    const buildInterfaceSaveParams = async (input: {
+      projectId: string;
+      catid?: string;
+      id?: string;
+      title?: string;
+      path?: string;
+      method?: string;
+      status?: string;
+      tag?: unknown;
+      req_params?: unknown;
+      req_query?: unknown;
+      req_headers?: unknown;
+      req_body_type?: string;
+      req_body_form?: unknown;
+      req_body_other?: unknown;
+      req_body_is_json_schema?: boolean;
+      res_body_type?: string;
+      res_body?: unknown;
+      res_body_is_json_schema?: boolean;
+      switch_notice?: boolean;
+      api_opened?: boolean;
+      desc?: string;
+      markdown?: string;
+      message?: string;
+    }): Promise<{ ok: true; params: any; isUpdate: boolean } | { ok: false; error: string }> => {
+      const isUpdate = Boolean(input.id);
+      let current: any | null = null;
+
+      if (isUpdate) {
+        current = await this.yapiService.getApiInterface(input.projectId, input.id as string);
+      }
+
+      const finalCatid = input.catid ?? (current ? String((current as any).catid ?? "") : "");
+      const finalTitle = input.title ?? (current ? String((current as any).title ?? "") : "");
+      const finalPath = input.path ?? (current ? String((current as any).path ?? "") : "");
+      const finalMethod = input.method ?? (current ? String((current as any).method ?? "") : "");
+
+      if (!finalCatid) return { ok: false, error: "缺少 catid：新增必填；更新可省略但必须能从原接口读取到" };
+      if (!finalTitle) return { ok: false, error: "缺少 title：新增必填；更新可省略但必须能从原接口读取到" };
+      if (!finalPath) return { ok: false, error: "缺少 path：新增必填；更新可省略但必须能从原接口读取到" };
+      if (!finalMethod) return { ok: false, error: "缺少 method：新增必填；更新可省略但必须能从原接口读取到" };
+
+      const params: any = {
+        project_id: input.projectId,
+        catid: finalCatid,
+        title: finalTitle,
+        path: finalPath,
+        method: finalMethod,
+      };
+
+      if (isUpdate) params.id = input.id;
+
+      const tagRaw = input.tag !== undefined ? input.tag : isUpdate ? (current as any)?.tag : undefined;
+      const tagResult = normalizeTagInput(tagRaw);
+      if (!tagResult.ok) return { ok: false, error: tagResult.error };
+      params.tag = tagResult.value;
+
+      params.status = input.status ?? (isUpdate ? (current as any)?.status : "undone");
+      params.desc = input.desc ?? (isUpdate ? (current as any)?.desc : "");
+      params.markdown = input.markdown ?? (isUpdate ? (current as any)?.markdown : "");
+      params.message = input.message ?? (isUpdate ? (current as any)?.message : "");
+
+      const reqParamsRaw = input.req_params !== undefined ? input.req_params : isUpdate ? (current as any)?.req_params : [];
+      const reqParamsParsed = normalizeJsonArrayInput(reqParamsRaw, "req_params");
+      if (!reqParamsParsed.ok) return { ok: false, error: reqParamsParsed.error };
+      params.req_params = reqParamsParsed.value;
+
+      const reqQueryRaw = input.req_query !== undefined ? input.req_query : isUpdate ? (current as any)?.req_query : [];
+      const reqQueryParsed = normalizeJsonArrayInput(reqQueryRaw, "req_query");
+      if (!reqQueryParsed.ok) return { ok: false, error: reqQueryParsed.error };
+      params.req_query = reqQueryParsed.value;
+
+      const reqHeadersRaw = input.req_headers !== undefined ? input.req_headers : isUpdate ? (current as any)?.req_headers : [];
+      const reqHeadersParsed = normalizeJsonArrayInput(reqHeadersRaw, "req_headers");
+      if (!reqHeadersParsed.ok) return { ok: false, error: reqHeadersParsed.error };
+      params.req_headers = reqHeadersParsed.value;
+
+      params.req_body_type = input.req_body_type ?? (isUpdate ? (current as any)?.req_body_type : "");
+
+      const reqBodyFormRaw = input.req_body_form !== undefined ? input.req_body_form : isUpdate ? (current as any)?.req_body_form : [];
+      const reqBodyFormParsed = normalizeJsonArrayInput(reqBodyFormRaw, "req_body_form");
+      if (!reqBodyFormParsed.ok) return { ok: false, error: reqBodyFormParsed.error };
+      params.req_body_form = reqBodyFormParsed.value;
+
+      const reqBodyOtherRaw = input.req_body_other !== undefined ? input.req_body_other : isUpdate ? (current as any)?.req_body_other : "";
+      const reqBodyOtherNormalized = normalizeStringOrJson(reqBodyOtherRaw, "req_body_other");
+      if (!reqBodyOtherNormalized.ok) return { ok: false, error: reqBodyOtherNormalized.error };
+      params.req_body_other = reqBodyOtherNormalized.value;
+
+      params.req_body_is_json_schema =
+        input.req_body_is_json_schema ?? (isUpdate ? (current as any)?.req_body_is_json_schema : undefined);
+
+      params.res_body_type = input.res_body_type ?? (isUpdate ? (current as any)?.res_body_type : "json");
+
+      const resBodyRaw = input.res_body !== undefined ? input.res_body : isUpdate ? (current as any)?.res_body : "";
+      const resBodyNormalized = normalizeStringOrJson(resBodyRaw, "res_body");
+      if (!resBodyNormalized.ok) return { ok: false, error: resBodyNormalized.error };
+      params.res_body = resBodyNormalized.value;
+
+      params.res_body_is_json_schema =
+        input.res_body_is_json_schema ?? (isUpdate ? (current as any)?.res_body_is_json_schema : undefined);
+
+      params.switch_notice = input.switch_notice ?? (isUpdate ? (current as any)?.switch_notice : undefined);
+      params.api_opened = input.api_opened ?? (isUpdate ? (current as any)?.api_opened : undefined);
+
+      return { ok: true, params, isUpdate };
+    };
+
     // 获取API接口详情
     this.server.tool(
       "yapi_get_api_desc",
@@ -139,6 +310,11 @@ export class YapiMcpServer {
             },
             其他信息: {
               接口文档: apiInterface.markdown
+            },
+            编辑建议: {
+              优先更新字段: "req_params / req_query / req_headers / req_body_* / res_body（把枚举值、中文备注、示例尽量放在这些结构字段里）",
+              避免滥用字段: "desc 只写简要概述；长文档写 markdown；不要用 desc 替代结构化字段",
+              对应开放API工具: "需要原始字段或精确对应开放 API 时，用 yapi_interface_* / yapi_open_import_data / yapi_project_get"
             }
           };
 
@@ -154,33 +330,83 @@ export class YapiMcpServer {
       }
     );
 
+    // 获取项目详情（/api/project/get）
+    this.server.tool(
+      "yapi_project_get",
+      "获取 YApi 项目详情（对应 /api/project/get）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+      },
+      async ({ projectId }) => {
+        try {
+          const projectInfo = await this.yapiService.getProjectInfo(projectId);
+          return { content: [{ type: "text", text: JSON.stringify(projectInfo, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`获取项目详情失败:`, error);
+          return { content: [{ type: "text", text: `获取项目详情失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 获取接口数据（/api/interface/get）
+    this.server.tool(
+      "yapi_interface_get",
+      "获取接口数据（对应 /api/interface/get，返回原始字段）",
+      {
+        projectId: z.string().describe("YApi项目ID（用于选择 token）"),
+        apiId: z.string().describe("接口ID"),
+      },
+      async ({ projectId, apiId }) => {
+        try {
+          const apiInterface = await this.yapiService.getApiInterface(projectId, apiId);
+          return { content: [{ type: "text", text: JSON.stringify(apiInterface, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`获取接口数据失败:`, error);
+          return { content: [{ type: "text", text: `获取接口数据失败: ${error}` }] };
+        }
+      },
+    );
+
     // 保存API接口
     this.server.tool(
       "yapi_save_api",
       "新增或更新YApi中的接口信息",
       {
         projectId: z.string().describe("YApi项目ID"),
-        catid: z.string().describe("接口分类ID，新增接口时必填"),
+        catid: z.string().optional().describe("接口分类ID；新增接口时必填，更新时可省略（会保留原值）"),
         id: z.string().optional().describe("接口ID，更新时必填，新增时不需要"),
-        title: z.string().describe("接口标题"),
-        path: z.string().describe("接口路径，如：/api/user"),
-        method: z.string().describe("请求方法，如：GET, POST, PUT, DELETE等"),
-        status: z.string().optional().describe("接口状态，done代表完成，undone代表未完成"),
-        tag: z.string().optional().describe("接口标签列表"),
-        req_params: z.string().optional().describe("路径参数，JSON格式数组，如：[{\"name\":\"id\",\"desc\":\"用户ID\"}]"),
-        req_query: z.string().optional().describe("查询参数，JSON格式数组，如：[{\"name\":\"page\",\"desc\":\"页码\",\"required\":\"1\"}]"),
-        req_headers: z.string().optional().describe("请求头参数，JSON格式数组，如：[{\"name\":\"Content-Type\",\"value\":\"application/json\"}]"),
-        req_body_type: z.string().optional().describe("请求体类型，如：form, json, file, raw"),
-        req_body_form: z.string().optional().describe("表单请求体，JSON格式数组"),
-        req_body_other: z.string().optional().describe("其他请求体（通常是JSON格式）"),
+        title: z.string().optional().describe("接口标题；新增接口时必填，更新时可省略（会保留原值）"),
+        path: z.string().optional().describe("接口路径，如：/api/user；新增接口时必填，更新时可省略（会保留原值）"),
+        method: z.string().optional().describe("请求方法，如：GET, POST, PUT, DELETE等；新增接口时必填，更新时可省略（会保留原值）"),
+        status: z.string().optional().describe("接口状态，done代表完成，undone代表未完成；更新时可省略（不覆盖原值）"),
+        tag: z.union([z.string(), z.array(z.string())]).optional().describe("接口标签列表；支持 JSON 数组字符串或字符串数组；更新时可省略（不覆盖原值）"),
+        req_params: z
+          .union([z.string(), z.array(yapiParamItemSchema)])
+          .optional()
+          .describe("路径参数；强烈建议填写（枚举值/中文备注放这里）；支持 JSON 数组字符串或数组"),
+        req_query: z
+          .union([z.string(), z.array(yapiParamItemSchema)])
+          .optional()
+          .describe("查询参数；支持 JSON 数组字符串或数组"),
+        req_headers: z
+          .union([z.string(), z.array(yapiHeaderItemSchema)])
+          .optional()
+          .describe("请求头参数；支持 JSON 数组字符串或数组"),
+        req_body_type: z.string().optional().describe("请求体类型（常见：raw/form/json/file）"),
+        req_body_form: z
+          .union([z.string(), z.array(yapiParamItemSchema)])
+          .optional()
+          .describe("表单请求体；支持 JSON 数组字符串或数组"),
+        req_body_other: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("其他请求体（通常是 JSON / JSON Schema）；支持字符串或对象/数组"),
         req_body_is_json_schema: z.boolean().optional().describe("是否开启JSON Schema，默认false"),
-        res_body_type: z.string().optional().describe("返回数据类型，如：json, raw"),
-        res_body: z.string().optional().describe("返回数据，如果res_body_is_json_schema为true则用json schema格式"),
+        res_body_type: z.string().optional().describe("返回数据类型（常见：json/raw）"),
+        res_body: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("返回数据；强烈建议填写（枚举值/中文备注放这里）；支持字符串或对象/数组（会自动序列化）"),
         res_body_is_json_schema: z.boolean().optional().describe("返回数据是否为JSON Schema，默认false"),
         switch_notice: z.boolean().optional().describe("开启接口运行通知，默认true"),
         api_opened: z.boolean().optional().describe("开启API文档页面，默认true"),
-        desc: z.string().optional().describe("接口描述"),
-        markdown: z.string().optional().describe("markdown格式的接口描述")
+        message: z.string().optional().describe("接口备注信息（对应 openapi 示例中的 message 字段）"),
+        desc: z.string().optional().describe("接口简要描述（不要把请求/响应结构都塞进 desc；结构请写到 req_* / res_body）"),
+        markdown: z.string().optional().describe("markdown格式的接口描述（补充说明/示例；结构仍建议写到 req_* / res_body）")
       },
       async ({
         projectId,
@@ -203,110 +429,50 @@ export class YapiMcpServer {
         res_body_is_json_schema,
         switch_notice,
         api_opened,
+        message,
         desc,
         markdown
       }) => {
         try {
-          // 准备接口参数
-          const params = {
-            project_id: projectId,
+          const built = await buildInterfaceSaveParams({
+            projectId,
             catid,
+            id,
             title,
             path,
             method,
-            status: status || 'undone',
-            tag: tag ? JSON.parse(tag) : [],
-            desc: desc || "",
-            markdown: markdown || ""
-          } as any;
+            status,
+            tag,
+            req_params,
+            req_query,
+            req_headers,
+            req_body_type,
+            req_body_form,
+            req_body_other,
+            req_body_is_json_schema,
+            res_body_type,
+            res_body,
+            res_body_is_json_schema,
+            switch_notice,
+            api_opened,
+            desc,
+            markdown,
+            message,
+          });
 
-          // 有ID则是更新，否则是新增
-          if (id) {
-            params.id = id;
-          }
-
-          // 处理可选参数，将字符串JSON转为对象
-          if (req_params) {
-            try {
-              params.req_params = JSON.parse(req_params);
-            } catch (e) {
-              return {
-                content: [{ type: "text", text: `路径参数JSON解析错误: ${e}` }],
-              };
-            }
-          }
-
-          if (req_query) {
-            try {
-              params.req_query = JSON.parse(req_query);
-            } catch (e) {
-              return {
-                content: [{ type: "text", text: `查询参数JSON解析错误: ${e}` }],
-              };
-            }
-          }
-
-          if (req_headers) {
-            try {
-              params.req_headers = JSON.parse(req_headers);
-            } catch (e) {
-              return {
-                content: [{ type: "text", text: `请求头参数JSON解析错误: ${e}` }],
-              };
-            }
-          }
-
-          if (req_body_type) {
-            params.req_body_type = req_body_type;
-          }
-
-          if (req_body_form) {
-            try {
-              params.req_body_form = JSON.parse(req_body_form);
-            } catch (e) {
-              return {
-                content: [{ type: "text", text: `表单请求体JSON解析错误: ${e}` }],
-              };
-            }
-          }
-
-          if (req_body_other) {
-            params.req_body_other = req_body_other;
-          }
-
-          if (req_body_is_json_schema !== undefined) {
-            params.req_body_is_json_schema = req_body_is_json_schema;
-          }
-
-          if (res_body_type) {
-            params.res_body_type = res_body_type;
-          }
-
-          if (res_body) {
-            params.res_body = res_body;
-          }
-
-          if (res_body_is_json_schema !== undefined) {
-            params.res_body_is_json_schema = res_body_is_json_schema;
-          }
-
-          if (switch_notice !== undefined) {
-            params.switch_notice = switch_notice;
-          }
-
-          if (api_opened !== undefined) {
-            params.api_opened = api_opened;
+          if (!built.ok) {
+            return { content: [{ type: "text", text: built.error }] };
           }
 
           // 调用API保存接口
-          const response = await this.yapiService.saveInterface(params);
+          const response = await this.yapiService.saveInterface(built.params);
 
           // 返回保存结果
           const resultApiId = response.data._id;
           return {
             content: [{ 
               type: "text", 
-              text: `接口${id ? '更新' : '新增'}成功！\n接口ID: ${resultApiId}\n接口名称: ${title}\n请求方法: ${method}\n接口路径: ${path}` 
+              text: `接口${id ? '更新' : '新增'}成功！\n接口ID: ${resultApiId}\n接口名称: ${built.params.title}\n请求方法: ${built.params.method}\n接口路径: ${built.params.path}` 
             }],
           };
         } catch (error) {
@@ -316,6 +482,256 @@ export class YapiMcpServer {
           };
         }
       }
+    );
+
+    // 新增接口分类（/api/interface/add_cat）
+    this.server.tool(
+      "yapi_interface_add_cat",
+      "新增接口分类（对应 /api/interface/add_cat）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+        name: z.string().describe("分类名称"),
+        desc: z.string().optional().describe("分类描述"),
+      },
+      async ({ projectId, name, desc }) => {
+        try {
+          const data = await this.yapiService.addCategory(projectId, name, desc || "");
+          return { content: [{ type: "text", text: `新增分类成功：\n${JSON.stringify(data, null, 2)}` }] };
+        } catch (error) {
+          this.logger.error(`新增接口分类失败:`, error);
+          return { content: [{ type: "text", text: `新增接口分类失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 获取菜单列表（/api/interface/getCatMenu）
+    this.server.tool(
+      "yapi_interface_get_cat_menu",
+      "获取菜单列表（对应 /api/interface/getCatMenu）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+      },
+      async ({ projectId }) => {
+        try {
+          const list = await this.yapiService.getCategoryList(projectId);
+          return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`获取菜单列表失败:`, error);
+          return { content: [{ type: "text", text: `获取菜单列表失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 获取接口列表数据（/api/interface/list）
+    this.server.tool(
+      "yapi_interface_list",
+      "获取接口列表数据（对应 /api/interface/list）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+        page: z.number().optional().describe("页码，默认 1"),
+        limit: z.number().optional().describe("每页数量，默认 10"),
+      },
+      async ({ projectId, page, limit }) => {
+        try {
+          const data = await this.yapiService.listInterfaces(projectId, page ?? 1, limit ?? 10);
+          return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`获取接口列表失败:`, error);
+          return { content: [{ type: "text", text: `获取接口列表失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 获取某个分类下接口列表（/api/interface/list_cat）
+    this.server.tool(
+      "yapi_interface_list_cat",
+      "获取某个分类下接口列表（对应 /api/interface/list_cat）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+        catId: z.string().describe("分类ID"),
+        page: z.number().optional().describe("页码，默认 1"),
+        limit: z.number().optional().describe("每页数量，默认 10"),
+      },
+      async ({ projectId, catId, page, limit }) => {
+        try {
+          const response = await this.yapiService.listCategoryInterfaces(projectId, catId, page ?? 1, limit ?? 10);
+          return { content: [{ type: "text", text: JSON.stringify(response.data, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`获取分类接口列表失败:`, error);
+          return { content: [{ type: "text", text: `获取分类接口列表失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 获取接口菜单列表（/api/interface/list_menu）
+    this.server.tool(
+      "yapi_interface_list_menu",
+      "获取接口菜单列表（对应 /api/interface/list_menu）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+      },
+      async ({ projectId }) => {
+        try {
+          const data = await this.yapiService.getInterfaceMenu(projectId);
+          return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`获取接口菜单列表失败:`, error);
+          return { content: [{ type: "text", text: `获取接口菜单列表失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 新增接口（/api/interface/add）
+    this.server.tool(
+      "yapi_interface_add",
+      "新增接口（对应 /api/interface/add）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+        catid: z.string().describe("接口分类ID"),
+        title: z.string().describe("接口标题"),
+        path: z.string().describe("接口路径"),
+        method: z.string().describe("请求方法"),
+        status: z.string().optional().describe("接口状态，默认 undone"),
+        tag: z.union([z.string(), z.array(z.string())]).optional().describe("标签"),
+        req_params: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("路径参数"),
+        req_query: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("查询参数"),
+        req_headers: z.union([z.string(), z.array(yapiHeaderItemSchema)]).optional().describe("请求头"),
+        req_body_type: z.string().optional().describe("请求体类型"),
+        req_body_form: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("表单请求体"),
+        req_body_other: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("其他请求体"),
+        req_body_is_json_schema: z.boolean().optional().describe("请求体是否 JSON Schema"),
+        res_body_type: z.string().optional().describe("响应类型，默认 json"),
+        res_body: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("响应内容"),
+        res_body_is_json_schema: z.boolean().optional().describe("响应是否 JSON Schema"),
+        switch_notice: z.boolean().optional().describe("是否通知"),
+        api_opened: z.boolean().optional().describe("是否公开"),
+        message: z.string().optional().describe("接口备注信息"),
+        desc: z.string().optional().describe("接口描述"),
+        markdown: z.string().optional().describe("markdown 描述"),
+      },
+      async (input) => {
+        try {
+          const built = await buildInterfaceSaveParams({ ...input, id: undefined });
+          if (!built.ok) return { content: [{ type: "text", text: built.error }] };
+          const response = await this.yapiService.addInterface(built.params);
+          return { content: [{ type: "text", text: JSON.stringify(response, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`新增接口失败:`, error);
+          return { content: [{ type: "text", text: `新增接口失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 更新接口（/api/interface/up）
+    this.server.tool(
+      "yapi_interface_up",
+      "更新接口（对应 /api/interface/up）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+        id: z.string().describe("接口ID"),
+        catid: z.string().optional().describe("分类ID（可省略，会保留原值）"),
+        title: z.string().optional().describe("接口标题（可省略，会保留原值）"),
+        path: z.string().optional().describe("接口路径（可省略，会保留原值）"),
+        method: z.string().optional().describe("请求方法（可省略，会保留原值）"),
+        status: z.string().optional().describe("接口状态"),
+        tag: z.union([z.string(), z.array(z.string())]).optional().describe("标签"),
+        req_params: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("路径参数"),
+        req_query: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("查询参数"),
+        req_headers: z.union([z.string(), z.array(yapiHeaderItemSchema)]).optional().describe("请求头"),
+        req_body_type: z.string().optional().describe("请求体类型"),
+        req_body_form: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("表单请求体"),
+        req_body_other: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("其他请求体"),
+        req_body_is_json_schema: z.boolean().optional().describe("请求体是否 JSON Schema"),
+        res_body_type: z.string().optional().describe("响应类型"),
+        res_body: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("响应内容"),
+        res_body_is_json_schema: z.boolean().optional().describe("响应是否 JSON Schema"),
+        switch_notice: z.boolean().optional().describe("是否通知"),
+        api_opened: z.boolean().optional().describe("是否公开"),
+        message: z.string().optional().describe("接口备注信息"),
+        desc: z.string().optional().describe("接口描述"),
+        markdown: z.string().optional().describe("markdown 描述"),
+      },
+      async (input) => {
+        try {
+          const built = await buildInterfaceSaveParams(input);
+          if (!built.ok) return { content: [{ type: "text", text: built.error }] };
+          const response = await this.yapiService.updateInterface(built.params);
+          return { content: [{ type: "text", text: JSON.stringify(response, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`更新接口失败:`, error);
+          return { content: [{ type: "text", text: `更新接口失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 新增或者更新接口（/api/interface/save）
+    this.server.tool(
+      "yapi_interface_save",
+      "新增或者更新接口（对应 /api/interface/save）",
+      {
+        projectId: z.string().describe("YApi项目ID"),
+        id: z.string().optional().describe("接口ID（有则更新，无则新增）"),
+        catid: z.string().optional().describe("接口分类ID"),
+        title: z.string().optional().describe("接口标题"),
+        path: z.string().optional().describe("接口路径"),
+        method: z.string().optional().describe("请求方法"),
+        status: z.string().optional().describe("接口状态"),
+        tag: z.union([z.string(), z.array(z.string())]).optional().describe("标签"),
+        req_params: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("路径参数"),
+        req_query: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("查询参数"),
+        req_headers: z.union([z.string(), z.array(yapiHeaderItemSchema)]).optional().describe("请求头"),
+        req_body_type: z.string().optional().describe("请求体类型"),
+        req_body_form: z.union([z.string(), z.array(yapiParamItemSchema)]).optional().describe("表单请求体"),
+        req_body_other: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("其他请求体"),
+        req_body_is_json_schema: z.boolean().optional().describe("请求体是否 JSON Schema"),
+        res_body_type: z.string().optional().describe("响应类型"),
+        res_body: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("响应内容"),
+        res_body_is_json_schema: z.boolean().optional().describe("响应是否 JSON Schema"),
+        switch_notice: z.boolean().optional().describe("是否通知"),
+        api_opened: z.boolean().optional().describe("是否公开"),
+        message: z.string().optional().describe("接口备注信息"),
+        desc: z.string().optional().describe("接口描述"),
+        markdown: z.string().optional().describe("markdown 描述"),
+      },
+      async (input) => {
+        try {
+          const built = await buildInterfaceSaveParams(input);
+          if (!built.ok) return { content: [{ type: "text", text: built.error }] };
+          const response = await this.yapiService.saveInterfaceUnified(built.params);
+          return { content: [{ type: "text", text: JSON.stringify(response, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`保存接口失败:`, error);
+          return { content: [{ type: "text", text: `保存接口失败: ${error}` }] };
+        }
+      },
+    );
+
+    // 服务端数据导入（/api/open/import_data）
+    this.server.tool(
+      "yapi_open_import_data",
+      "服务端数据导入（对应 /api/open/import_data）",
+      {
+        projectId: z.string().describe("YApi项目ID（用于选择 token）"),
+        type: z.string().describe("导入方式，如 swagger"),
+        merge: z.enum(["normal", "good", "merge"]).describe("同步模式：normal/good/merge"),
+        json: z.union([z.string(), z.record(z.any()), z.array(z.any())]).optional().describe("导入数据 JSON（会自动序列化为字符串）"),
+        url: z.string().optional().describe("导入数据 URL（提供后会走 url 方式）"),
+      },
+      async ({ projectId, type, merge, json, url }) => {
+        try {
+          let jsonString: string | undefined;
+          if (json !== undefined) {
+            const normalized = normalizeStringOrJson(json, "json");
+            if (!normalized.ok) return { content: [{ type: "text", text: normalized.error }] };
+            jsonString = normalized.value;
+          }
+          const data = await this.yapiService.importData(projectId, { type, merge, json: jsonString, url });
+          return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+        } catch (error) {
+          this.logger.error(`导入数据失败:`, error);
+          return { content: [{ type: "text", text: `导入数据失败: ${error}` }] };
+        }
+      },
     );
 
     // 搜索API接口
@@ -482,20 +898,20 @@ export class YapiMcpServer {
       "yapi_get_categories",
       "获取YApi项目下的接口分类列表，以及每个分类下的接口信息",
       {
-        projectId: z.string().describe("YApi项目ID")
+        projectId: z.string().describe("YApi项目ID"),
+        includeApis: z.boolean().optional().describe("是否包含分类下接口列表，默认 true"),
+        limitPerCategory: z.number().optional().describe("每个分类最多返回多少接口（默认 100）")
       },
-      async ({ projectId }) => {
+      async ({ projectId, includeApis, limitPerCategory }) => {
         try {
-          // 获取项目信息
-          const projectInfo = this.yapiService.getProjectInfoCache().get(projectId);
-          if (!projectInfo) {
-            return {
-              content: [{ type: "text", text: `未找到项目ID为 ${projectId} 的项目信息，请确认项目ID正确` }],
-            };
-          }
+          const shouldIncludeApis = includeApis ?? true;
+          const perCatLimit = limitPerCategory ?? 100;
 
-          // 获取项目下的分类列表
-          const categoryList = this.yapiService.getCategoryListCache().get(projectId);
+          // 获取项目信息（必要时从 API 拉取）
+          const projectInfo = await this.yapiService.getProjectInfo(projectId);
+
+          // 获取项目下的分类列表（必要时从 API 拉取）
+          const categoryList = await this.yapiService.getCategoryList(projectId);
 
           if (!categoryList || categoryList.length === 0) {
             return {
@@ -503,11 +919,34 @@ export class YapiMcpServer {
             };
           }
 
+          if (!shouldIncludeApis) {
+            const simplified = categoryList.map(cat => ({
+              分类ID: cat._id,
+              分类名称: cat.name,
+              分类描述: cat.desc || "无描述",
+              创建时间: new Date(cat.add_time).toLocaleString(),
+              更新时间: new Date(cat.up_time).toLocaleString(),
+            }));
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `项目 "${projectInfo.name}" (ID: ${projectId}) 下共有 ${categoryList.length} 个接口分类:\n\n${JSON.stringify(
+                    simplified,
+                    null,
+                    2,
+                  )}`,
+                },
+              ],
+            };
+          }
+
           // 构建包含接口列表的分类信息
           const categoriesWithApisPromises = categoryList.map(async (cat) => {
             // 获取分类下的接口列表
             try {
-              const apis = await this.yapiService.getCategoryApis(projectId, cat._id);
+              const apisResponse = await this.yapiService.listCategoryInterfaces(projectId, cat._id, 1, perCatLimit);
+              const apis = apisResponse.data.list;
 
               // 将接口信息简化为所需字段
               const simplifiedApis = apis?.map(api => ({

--- a/src/services/yapi/api.ts
+++ b/src/services/yapi/api.ts
@@ -52,6 +52,10 @@ export class YApiService {
     this.cookieHeader = cookieHeader ? String(cookieHeader).trim() : null;
   }
 
+  hasCookieAuth(): boolean {
+    return Boolean(this.cookieHeader);
+  }
+
   /**
    * 动态更新某个项目的 token（用于全局模式缓存刷新）
    */
@@ -103,6 +107,33 @@ export class YApiService {
 
   hasProjectToken(projectId: string): boolean {
     return Boolean(this.getToken(projectId));
+  }
+
+  /**
+   * 搜索项目（/api/project/search?q=...）
+   * 仅在全局模式（Cookie 登录态）下更可靠。
+   */
+  async searchProjects(q: string): Promise<any[]> {
+    const res = await this.globalSearch(q);
+    return res.project;
+  }
+
+  /**
+   * 全局搜索（/api/project/search?q=...）
+   * 注意：该接口除了 project 之外，还会返回 group / interface。
+   */
+  async globalSearch(q: string): Promise<{ project: any[]; group: any[]; interface: any[] }> {
+    const keyword = String(q ?? "").trim();
+    if (!keyword) return { project: [], group: [], interface: [] };
+
+    const response = await this.request<any>("/api/project/search", { q: keyword }, undefined, "GET");
+    if (response?.errcode !== 0) throw new Error(response?.errmsg || "搜索失败");
+
+    const data = response?.data ?? {};
+    const projects = Array.isArray(data.project) ? data.project : Array.isArray(data.projects) ? data.projects : [];
+    const groups = Array.isArray(data.group) ? data.group : Array.isArray(data.groups) ? data.groups : [];
+    const interfaces = Array.isArray(data.interface) ? data.interface : Array.isArray(data.interfaces) ? data.interfaces : [];
+    return { project: projects, group: groups, interface: interfaces };
   }
 
   private async request<T>(
@@ -453,19 +484,128 @@ export class YApiService {
     );
     
     try {
-      // 1. 获取所有项目信息（或根据关键字过滤）
-      await this.loadAllProjectInfo();
-      let projects = Array.from(this.projectInfoCache.values());
-      
-      // 如果指定了项目关键字，过滤项目列表
-      if (projectKeyword && projectKeyword.trim().length > 0) {
-        const keyword = projectKeyword.trim().toLowerCase();
-        projects = projects.filter(project => {
-          const name = String((project as any)?.name ?? "").toLowerCase();
-          const desc = String((project as any)?.desc ?? "").toLowerCase();
-          const id = String((project as any)?._id ?? "");
-          return name.includes(keyword) || desc.includes(keyword) || id.includes(keyword);
-        });
+      // 1. 获取项目列表（全局模式优先走服务端 project/search，避免本地全量加载）
+      let projects: any[] = [];
+
+      if (projectKeyword && projectKeyword.trim().length > 0 && this.hasCookieAuth()) {
+        projects = await this.searchProjects(projectKeyword);
+
+        // project/search 可能返回的是最小字段集合，这里做一下标准化
+        projects = projects
+          .map(p => ({
+            _id: p?._id ?? p?.id ?? p?.project_id,
+            name: p?.name ?? p?.project_name ?? p?.title ?? "",
+            desc: p?.desc ?? "",
+            group_id: p?.group_id ?? p?.groupId,
+            basepath: p?.basepath ?? p?.base_path ?? "/",
+          }))
+          .filter(p => p._id != null);
+
+        // 某些部署的 project/search 只搜名称，不搜描述；为避免行为变化，空结果时回退到本地过滤
+        if (projects.length === 0) {
+          this.logger.debug("project/search 返回空结果，回退到本地项目缓存过滤");
+          await this.loadAllProjectInfo();
+          projects = Array.from(this.projectInfoCache.values());
+
+          const keyword = projectKeyword.trim().toLowerCase();
+          projects = projects.filter(project => {
+            const name = String((project as any)?.name ?? "").toLowerCase();
+            const desc = String((project as any)?.desc ?? "").toLowerCase();
+            const id = String((project as any)?._id ?? "");
+            return name.includes(keyword) || desc.includes(keyword) || id.includes(keyword);
+          });
+        }
+      } else if (this.hasCookieAuth() && (projectKeyword || nameKeywords.length || pathKeywords.length || tagKeywords.length)) {
+        // 全局模式：若提供了任意关键词，优先用 /api/project/search 一次性拿 interface 命中集，避免逐项目扫接口
+        const q = [projectKeyword, ...nameKeywords, ...pathKeywords, ...tagKeywords].filter(Boolean).join(" ").trim();
+        if (q) {
+          const searched = await this.globalSearch(q);
+
+          const projectNameById = new Map<string, string>();
+          for (const p of searched.project) {
+            const pid = String(p?._id ?? p?.id ?? p?.projectId ?? p?.project_id ?? "");
+            if (!pid) continue;
+            const name = String(p?.name ?? p?.project_name ?? p?.title ?? "").trim();
+            if (name) projectNameById.set(pid, name);
+          }
+
+          const candidates = (searched.interface ?? [])
+            .map((it: any) => ({
+              _id: String(it?._id ?? it?.id ?? ""),
+              projectId: String(it?.projectId ?? it?.project_id ?? it?.project ?? ""),
+              title: String(it?.title ?? ""),
+              addTime: it?.addTime ?? it?.add_time,
+              upTime: it?.upTime ?? it?.up_time,
+            }))
+            .filter(it => it._id && it.projectId);
+
+          if (candidates.length === 0) {
+            this.logger.info("全局搜索未命中任何接口");
+            return { total: 0, list: [] };
+          }
+
+          const limitedCandidates = candidates.slice(0, limit);
+          const byProject = new Map<string, typeof limitedCandidates>();
+          for (const it of limitedCandidates) {
+            const arr = byProject.get(it.projectId) ?? [];
+            arr.push(it);
+            byProject.set(it.projectId, arr);
+          }
+
+          const catNameByProject = new Map<string, Map<string, string>>();
+          await Promise.all(
+            Array.from(byProject.keys()).map(async pid => {
+              try {
+                const cats = await this.getCategoryList(pid);
+                const m = new Map<string, string>();
+                for (const c of cats) m.set(String((c as any)._id), String((c as any).name ?? ""));
+                catNameByProject.set(pid, m);
+              } catch {
+                // ignore
+              }
+            }),
+          );
+
+          const results: Array<any> = [];
+          for (const it of limitedCandidates) {
+            try {
+              const detail = await this.getApiInterface(it.projectId, it._id);
+              const catid = String((detail as any).catid ?? "");
+              const catName = catid ? catNameByProject.get(it.projectId)?.get(catid) : undefined;
+
+              results.push({
+                _id: String((detail as any)._id ?? it._id),
+                title: String((detail as any).title ?? it.title ?? ""),
+                path: String((detail as any).path ?? ""),
+                method: String((detail as any).method ?? ""),
+                project_id: Number.isFinite(Number(it.projectId)) ? Number(it.projectId) : it.projectId,
+                add_time: (detail as any).add_time ?? it.addTime ?? Date.now() / 1000,
+                up_time: (detail as any).up_time ?? it.upTime ?? Date.now() / 1000,
+                catid: (detail as any).catid,
+                project_name: projectNameById.get(it.projectId) || undefined,
+                cat_name: catName || undefined,
+              });
+            } catch (e) {
+              this.logger.debug(`全局搜索命中接口但拉取详情失败(projectId=${it.projectId}, id=${it._id}):`, e);
+            }
+          }
+
+          const deduplicated = this.deduplicateResults(results);
+          return { total: deduplicated.length, list: deduplicated };
+        }
+      } else {
+        await this.loadAllProjectInfo();
+        projects = Array.from(this.projectInfoCache.values());
+
+        if (projectKeyword && projectKeyword.trim().length > 0) {
+          const keyword = projectKeyword.trim().toLowerCase();
+          projects = projects.filter(project => {
+            const name = String((project as any)?.name ?? "").toLowerCase();
+            const desc = String((project as any)?.desc ?? "").toLowerCase();
+            const id = String((project as any)?._id ?? "");
+            return name.includes(keyword) || desc.includes(keyword) || id.includes(keyword);
+          });
+        }
       }
       
       // 限制只搜索前几个匹配的项目

--- a/src/services/yapi/api.ts
+++ b/src/services/yapi/api.ts
@@ -72,7 +72,13 @@ export class YApiService {
     return this.tokenMap.get(projectId) || this.defaultToken;
   }
 
-  private async request<T>(endpoint: string, params: Record<string, any> = {}, projectId?: string, method: 'GET' | 'POST' = 'GET'): Promise<T> {
+  private async request<T>(
+    endpoint: string,
+    params: Record<string, any> = {},
+    projectId?: string,
+    method: "GET" | "POST" = "GET",
+    options: { contentType?: "json" | "form" } = {},
+  ): Promise<T> {
     try {
       this.logger.debug(`调用 ${this.baseUrl}${endpoint} 方法: ${method}`);
       
@@ -93,10 +99,25 @@ export class YApiService {
           }
         });
       } else {
-        response = await axios.post(`${this.baseUrl}${endpoint}`, {
+        const contentType = options.contentType || "json";
+        const body = {
           ...params,
-          token: token
-        });
+          token: token,
+        };
+        if (contentType === "form") {
+          const form = new URLSearchParams();
+          for (const [key, value] of Object.entries(body)) {
+            if (value === undefined || value === null) continue;
+            if (typeof value === "string") form.set(key, value);
+            else if (typeof value === "number" || typeof value === "boolean") form.set(key, String(value));
+            else form.set(key, JSON.stringify(value));
+          }
+          response = await axios.post(`${this.baseUrl}${endpoint}`, form, {
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          });
+        } else {
+          response = await axios.post(`${this.baseUrl}${endpoint}`, body);
+        }
       }
 
       return response.data;
@@ -138,6 +159,25 @@ export class YApiService {
       this.logger.error(`获取项目分类列表失败, projectId=${projectId}:`, error);
       throw error;
     }
+  }
+
+  /**
+   * 新增接口分类（/api/interface/add_cat）
+   */
+  async addCategory(projectId: string, name: string, desc: string = ""): Promise<any> {
+    const response = await this.request<any>(
+      "/api/interface/add_cat",
+      { project_id: projectId, name, desc },
+      projectId,
+      "POST",
+      { contentType: "form" },
+    );
+    if (response?.errcode !== 0) {
+      throw new Error(response?.errmsg || "新增接口分类失败");
+    }
+    // 成功后清理缓存，避免读到旧数据
+    this.categoryListCache.delete(projectId);
+    return response.data;
   }
 
   /**
@@ -215,6 +255,17 @@ export class YApiService {
   }
 
   /**
+   * 获取接口菜单列表（/api/interface/list_menu）
+   */
+  async getInterfaceMenu(projectId: string): Promise<any[]> {
+    const response = await this.request<any>("/api/interface/list_menu", { project_id: projectId }, projectId);
+    if (response?.errcode !== 0) {
+      throw new Error(response?.errmsg || "获取接口菜单列表失败");
+    }
+    return response.data;
+  }
+
+  /**
    * 获取接口详情
    * @param projectId 项目ID
    * @param id 接口ID
@@ -265,6 +316,61 @@ export class YApiService {
       this.logger.error(`${params.id ? '更新' : '新增'}接口失败:`, error);
       throw error;
     }
+  }
+
+  /**
+   * 新增接口（/api/interface/add）
+   */
+  async addInterface(params: SaveApiInterfaceParams): Promise<SaveApiResponse> {
+    const response = await this.request<SaveApiResponse>("/api/interface/add", params, params.project_id, "POST");
+    if (response.errcode !== 0) {
+      throw new Error(response.errmsg || "新增接口失败");
+    }
+    return response;
+  }
+
+  /**
+   * 更新接口（/api/interface/up）
+   */
+  async updateInterface(params: SaveApiInterfaceParams): Promise<SaveApiResponse> {
+    const response = await this.request<SaveApiResponse>("/api/interface/up", params, params.project_id, "POST");
+    if (response.errcode !== 0) {
+      throw new Error(response.errmsg || "更新接口失败");
+    }
+    return response;
+  }
+
+  /**
+   * 新增或更新接口（/api/interface/save）
+   */
+  async saveInterfaceUnified(params: SaveApiInterfaceParams): Promise<any> {
+    const response = await this.request<any>("/api/interface/save", params, params.project_id, "POST");
+    if (response?.errcode !== 0) {
+      throw new Error(response?.errmsg || "保存接口失败");
+    }
+    return response;
+  }
+
+  /**
+   * 获取接口列表数据（/api/interface/list）
+   */
+  async listInterfaces(projectId: string, page: number = 1, limit: number = 10): Promise<any> {
+    const response = await this.request<any>("/api/interface/list", { project_id: projectId, page, limit }, projectId);
+    if (response?.errcode !== 0) {
+      throw new Error(response?.errmsg || "获取接口列表失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 服务端数据导入（/api/open/import_data）
+   */
+  async importData(projectId: string, params: { type: string; merge: string; json?: string; url?: string }): Promise<any> {
+    const response = await this.request<any>("/api/open/import_data", params, projectId, "POST", { contentType: "form" });
+    if (response?.errcode !== 0) {
+      throw new Error(response?.errmsg || "导入数据失败");
+    }
+    return response.data;
   }
 
   /**
@@ -463,14 +569,7 @@ export class YApiService {
    */
   async getCategoryApis(projectId: string, catId: string): Promise<Array<ApiSearchResultItem>> {
     try {
-      const params = {
-        project_id: projectId,
-        catid: catId,
-        page: 1,
-        limit: 100 // 默认获取100个，如果需要更多可以考虑分页
-      };
-      
-      const response = await this.request<ApiSearchResponse>("/api/interface/list_cat", params, projectId);
+      const response = await this.listCategoryInterfaces(projectId, catId, 1, 100);
       
       if (response.errcode !== 0) {
         throw new Error(response.errmsg || "获取分类接口列表失败");
@@ -481,5 +580,25 @@ export class YApiService {
       this.logger.error(`获取分类接口列表失败, projectId=${projectId}, catId=${catId}:`, error);
       throw error;
     }
+  }
+
+  /**
+   * 获取某个分类下接口列表（/api/interface/list_cat）
+   */
+  async listCategoryInterfaces(projectId: string, catId: string, page: number = 1, limit: number = 10): Promise<ApiSearchResponse> {
+    const params = {
+      project_id: projectId,
+      catid: catId,
+      page,
+      limit,
+    };
+
+    const response = await this.request<ApiSearchResponse>("/api/interface/list_cat", params, projectId);
+
+    if (response.errcode !== 0) {
+      throw new Error(response.errmsg || "获取分类接口列表失败");
+    }
+
+    return response;
   }
 } 

--- a/src/services/yapi/api.ts
+++ b/src/services/yapi/api.ts
@@ -460,11 +460,12 @@ export class YApiService {
       // 如果指定了项目关键字，过滤项目列表
       if (projectKeyword && projectKeyword.trim().length > 0) {
         const keyword = projectKeyword.trim().toLowerCase();
-        projects = projects.filter(project => 
-          project.name.toLowerCase().includes(keyword) || 
-          project.desc.toLowerCase().includes(keyword) ||
-          String(project._id).includes(keyword)
-        );
+        projects = projects.filter(project => {
+          const name = String((project as any)?.name ?? "").toLowerCase();
+          const desc = String((project as any)?.desc ?? "").toLowerCase();
+          const id = String((project as any)?._id ?? "");
+          return name.includes(keyword) || desc.includes(keyword) || id.includes(keyword);
+        });
       }
       
       // 限制只搜索前几个匹配的项目

--- a/src/services/yapi/api.ts
+++ b/src/services/yapi/api.ts
@@ -45,6 +45,17 @@ export class YApiService {
     this.logger.info(`YApiService已初始化，baseUrl=${baseUrl}`);
   }
 
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  buildInterfaceWebUrl(projectId: string, apiId: string): string {
+    const base = String(this.baseUrl || "").replace(/\/+$/, "");
+    const pid = encodeURIComponent(String(projectId ?? ""));
+    const aid = encodeURIComponent(String(apiId ?? ""));
+    return `${base}/project/${pid}/interface/api/${aid}`;
+  }
+
   /**
    * 设置 Cookie（全局模式：使用登录态调用 YApi；也可与 token 并用）
    */

--- a/src/services/yapi/api.ts
+++ b/src/services/yapi/api.ts
@@ -17,6 +17,7 @@ export class YApiService {
   private readonly baseUrl: string;
   private readonly tokenMap: Map<string, string>;
   private readonly defaultToken: string;
+  private cookieHeader: string | null = null;
   private projectInfoCache: Map<string, ProjectInfo> = new Map(); // 缓存项目信息
   private categoryListCache: Map<string, CategoryInfo[]> = new Map(); // 缓存项目分类列表
   private readonly logger: Logger;
@@ -42,6 +43,13 @@ export class YApiService {
     }
     
     this.logger.info(`YApiService已初始化，baseUrl=${baseUrl}`);
+  }
+
+  /**
+   * 设置 Cookie（全局模式：使用登录态调用 YApi；也可与 token 并用）
+   */
+  setCookieHeader(cookieHeader: string | null): void {
+    this.cookieHeader = cookieHeader ? String(cookieHeader).trim() : null;
   }
 
   /**
@@ -93,6 +101,10 @@ export class YApiService {
     return this.tokenMap.get(projectId) || this.defaultToken;
   }
 
+  hasProjectToken(projectId: string): boolean {
+    return Boolean(this.getToken(projectId));
+  }
+
   private async request<T>(
     endpoint: string,
     params: Record<string, any> = {},
@@ -105,26 +117,29 @@ export class YApiService {
       
       // 使用项目ID获取对应的token，如果没有提供项目ID则使用默认token
       const token = projectId ? this.getToken(projectId) : this.defaultToken;
+      const cookieHeader = this.cookieHeader;
       
-      if (!token) {
+      if (!token && !cookieHeader) {
         const pid = projectId ? `projectId=${projectId}` : "projectId=未提供";
         throw new Error(`未配置 token（${pid}）。如使用全局模式，请先调用 yapi_update_token 生成本地缓存；或通过 --yapi-token / YAPI_TOKEN 配置项目 token`);
       }
       
       let response;
+      const headers: Record<string, string> | undefined = cookieHeader ? { Cookie: cookieHeader } : undefined;
       
       if (method === 'GET') {
         response = await axios.get(`${this.baseUrl}${endpoint}`, {
           params: {
             ...params,
-            token: token
-          }
+            ...(token ? { token } : {})
+          },
+          headers
         });
       } else {
         const contentType = options.contentType || "json";
         const body = {
           ...params,
-          token: token,
+          ...(token ? { token } : {}),
         };
         if (contentType === "form") {
           const form = new URLSearchParams();
@@ -135,22 +150,26 @@ export class YApiService {
             else form.set(key, JSON.stringify(value));
           }
           response = await axios.post(`${this.baseUrl}${endpoint}`, form, {
-            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            headers: { "Content-Type": "application/x-www-form-urlencoded", ...(headers ?? {}) },
           });
         } else {
-          response = await axios.post(`${this.baseUrl}${endpoint}`, body);
+          response = await axios.post(`${this.baseUrl}${endpoint}`, body, { headers });
         }
       }
 
       return response.data;
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
-        throw {
-          status: error.response.status,
-          message: error.response.data?.errmsg || "未知错误",
-        };
+        const errmsg =
+          (typeof error.response.data === "object" && error.response.data
+            ? (error.response.data as any).errmsg
+            : undefined) ||
+          error.message ||
+          "未知错误";
+        throw new Error(errmsg);
       }
-      throw new Error("与YApi服务器通信失败");
+      if (error instanceof Error) throw error;
+      throw new Error(`与YApi服务器通信失败: ${String(error)}`);
     }
   }
 

--- a/src/services/yapi/api.ts
+++ b/src/services/yapi/api.ts
@@ -45,6 +45,27 @@ export class YApiService {
   }
 
   /**
+   * 动态更新某个项目的 token（用于全局模式缓存刷新）
+   */
+  setProjectToken(projectId: string, token: string): void {
+    if (!projectId || !token) return;
+    this.tokenMap.set(String(projectId), String(token));
+  }
+
+  /**
+   * 批量更新项目 token（用于全局模式缓存刷新）
+   */
+  setProjectTokens(tokens: Map<string, string>, options: { overwrite?: boolean } = {}): void {
+    const overwrite = options.overwrite !== false;
+    tokens.forEach((token, projectId) => {
+      const pid = String(projectId);
+      if (!pid || !token) return;
+      if (!overwrite && this.tokenMap.has(pid)) return;
+      this.tokenMap.set(pid, String(token));
+    });
+  }
+
+  /**
    * 获取已配置的项目ID列表
    */
   getConfiguredProjectIds(): string[] {
@@ -86,7 +107,8 @@ export class YApiService {
       const token = projectId ? this.getToken(projectId) : this.defaultToken;
       
       if (!token) {
-        throw new Error(`未配置项目ID ${projectId} 的token`);
+        const pid = projectId ? `projectId=${projectId}` : "projectId=未提供";
+        throw new Error(`未配置 token（${pid}）。如使用全局模式，请先调用 yapi_update_token 生成本地缓存；或通过 --yapi-token / YAPI_TOKEN 配置项目 token`);
       }
       
       let response;

--- a/src/services/yapi/auth.ts
+++ b/src/services/yapi/auth.ts
@@ -261,13 +261,20 @@ export class YApiAuthService {
     const session = await this.login(Boolean(options.forceLogin));
     const groups = await this.listGroups(session);
     const projects: any[] = [];
+    const seenProjectId = new Set<string>();
 
     for (const g of groups) {
       const groupId = String(g?._id ?? g?.id ?? "");
       if (!groupId) continue;
       try {
         const list = await this.listProjectsInGroup(session, groupId);
-        projects.push(...list);
+        for (const p of list) {
+          const pid = String(p?._id ?? p?.id ?? "");
+          if (!pid) continue;
+          if (seenProjectId.has(pid)) continue;
+          seenProjectId.add(pid);
+          projects.push(p);
+        }
       } catch (e) {
         this.logger.warn(`获取分组项目列表失败(groupId=${groupId}): ${e}`);
       }

--- a/src/services/yapi/auth.ts
+++ b/src/services/yapi/auth.ts
@@ -4,6 +4,45 @@ import { YApiAuthCache, YApiSessionCookie } from "./authCache";
 
 type JsonObject = Record<string, any>;
 
+function looksLikeToken(val: unknown): boolean {
+  if (typeof val !== "string") return false;
+  const s = val.trim();
+  if (s.length < 24) return false;
+  if (s.length > 128) return false;
+  if (/^[a-f0-9]{32}$/i.test(s)) return true;
+  if (/^[a-f0-9]{64}$/i.test(s)) return true;
+  if (!/^[a-zA-Z0-9_-]+$/.test(s)) return false;
+  if (!/[a-zA-Z]/.test(s) || !/[0-9]/.test(s)) return false;
+  return true;
+}
+
+function findTokenInObject(obj: unknown, depth: number = 0): string | undefined {
+  if (depth > 6) return undefined;
+  if (!obj) return undefined;
+  if (typeof obj === "string") return looksLikeToken(obj) ? obj.trim() : undefined;
+  if (typeof obj !== "object") return undefined;
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      const hit = findTokenInObject(item, depth + 1);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+
+  const record = obj as Record<string, unknown>;
+  const preferredKeys = ["token", "project_token", "projectToken", "projectTokenValue"];
+  for (const key of preferredKeys) {
+    const v = record[key];
+    if (typeof v === "string" && looksLikeToken(v)) return v.trim();
+  }
+
+  for (const key of Object.keys(record)) {
+    const hit = findTokenInObject(record[key], depth + 1);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
 function pickCookieValue(setCookie: string[] | undefined, key: string): string | undefined {
   if (!setCookie || setCookie.length === 0) return undefined;
   const prefix = `${key}=`;
@@ -49,6 +88,12 @@ export class YApiAuthService {
 
   loadCachedProjectTokens(): Map<string, string> {
     return this.cache.loadProjectTokens();
+  }
+
+  getCachedCookieHeader(): string | null {
+    const cached = this.cache.loadSession();
+    if (!this.isSessionValid(cached)) return null;
+    return this.getCookieHeader(cached);
   }
 
   private getCookieHeader(session: YApiSessionCookie): string {
@@ -124,6 +169,28 @@ export class YApiAuthService {
     }
   }
 
+  private async cookieRequestText(
+    endpoint: string,
+    session: YApiSessionCookie,
+    options: { params?: JsonObject } = {},
+  ): Promise<string> {
+    try {
+      const url = `${this.baseUrl}${endpoint}`;
+      const cookie = this.getCookieHeader(session);
+      const headers: Record<string, string> = {
+        Cookie: cookie,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      };
+      const res = await axios.get(url, { params: options.params, headers, responseType: "text" });
+      return String(res.data ?? "");
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        throw new Error((error.response.data as any)?.errmsg || "请求失败");
+      }
+      throw error instanceof Error ? error : new Error("请求失败");
+    }
+  }
+
   private async listGroups(session: YApiSessionCookie): Promise<any[]> {
     // 有些实例同时支持 group/get_mygroup 和 group/list，这里尽量都试一下并去重
     const groups: any[] = [];
@@ -176,10 +243,44 @@ export class YApiAuthService {
     return res.data;
   }
 
+  private async getProjectTokenFromSettingPage(session: YApiSessionCookie, projectId: string): Promise<string | undefined> {
+    const html = await this.cookieRequestText(`/project/${encodeURIComponent(projectId)}/setting`, session);
+    const tokenRegexes = [
+      /(?:project\s*token|项目\s*token|token)\s*[:：]\s*([a-zA-Z0-9_-]{24,128})/i,
+      /name\s*=\s*"token"[\s\S]{0,200}?value\s*=\s*"([a-zA-Z0-9_-]{24,128})"/i,
+      /id\s*=\s*"token"[\s\S]{0,200}?value\s*=\s*"([a-zA-Z0-9_-]{24,128})"/i,
+    ];
+    for (const re of tokenRegexes) {
+      const m = re.exec(html);
+      if (m && m[1] && looksLikeToken(m[1])) return m[1].trim();
+    }
+    return undefined;
+  }
+
+  async listAccessibleProjects(options: { forceLogin?: boolean } = {}): Promise<{ groups: any[]; projects: any[] }> {
+    const session = await this.login(Boolean(options.forceLogin));
+    const groups = await this.listGroups(session);
+    const projects: any[] = [];
+
+    for (const g of groups) {
+      const groupId = String(g?._id ?? g?.id ?? "");
+      if (!groupId) continue;
+      try {
+        const list = await this.listProjectsInGroup(session, groupId);
+        projects.push(...list);
+      } catch (e) {
+        this.logger.warn(`获取分组项目列表失败(groupId=${groupId}): ${e}`);
+      }
+    }
+
+    return { groups, projects };
+  }
+
   async refreshProjectTokens(
     options: { forceLogin?: boolean } = {},
-  ): Promise<{ tokens: Map<string, string>; projects: any[]; groups: any[] }> {
+  ): Promise<{ tokens: Map<string, string>; projects: any[]; groups: any[]; cookieHeader: string }> {
     const session = await this.login(Boolean(options.forceLogin));
+    const cookieHeader = this.getCookieHeader(session);
     const groups = await this.listGroups(session);
     const projects: any[] = [];
 
@@ -199,16 +300,27 @@ export class YApiAuthService {
       const projectId = String(p?._id ?? p?.id ?? "");
       if (!projectId) continue;
       try {
+        const tokenFromList = findTokenInObject(p);
+        if (tokenFromList) {
+          tokens.set(projectId, tokenFromList);
+          continue;
+        }
+
         const detail = await this.getProjectDetail(session, projectId);
-        const token = String(detail?.token ?? "").trim();
-        if (token) tokens.set(projectId, token);
+        const tokenFromGet = findTokenInObject(detail);
+        if (tokenFromGet) {
+          tokens.set(projectId, tokenFromGet);
+          continue;
+        }
+
+        const tokenFromHtml = await this.getProjectTokenFromSettingPage(session, projectId);
+        if (tokenFromHtml) tokens.set(projectId, tokenFromHtml);
       } catch (e) {
         this.logger.warn(`获取项目 token 失败(projectId=${projectId}): ${e}`);
       }
     }
 
     this.cache.saveProjectTokens(tokens);
-    return { tokens, projects, groups };
+    return { tokens, projects, groups, cookieHeader };
   }
 }
-

--- a/src/services/yapi/auth.ts
+++ b/src/services/yapi/auth.ts
@@ -1,0 +1,214 @@
+import axios, { AxiosError } from "axios";
+import { Logger } from "./logger";
+import { YApiAuthCache, YApiSessionCookie } from "./authCache";
+
+type JsonObject = Record<string, any>;
+
+function pickCookieValue(setCookie: string[] | undefined, key: string): string | undefined {
+  if (!setCookie || setCookie.length === 0) return undefined;
+  const prefix = `${key}=`;
+  for (const item of setCookie) {
+    const trimmed = String(item || "").trim();
+    if (!trimmed.startsWith(prefix)) continue;
+    const value = trimmed.slice(prefix.length).split(";")[0];
+    return value || undefined;
+  }
+  return undefined;
+}
+
+function pickCookieExpiresAt(setCookie: string[] | undefined, key: string): number | undefined {
+  if (!setCookie || setCookie.length === 0) return undefined;
+  const prefix = `${key}=`;
+  for (const item of setCookie) {
+    const trimmed = String(item || "").trim();
+    if (!trimmed.startsWith(prefix)) continue;
+    const parts = trimmed.split(";").map(s => s.trim());
+    const expiresPart = parts.find(p => /^expires=/i.test(p));
+    if (!expiresPart) return undefined;
+    const dateStr = expiresPart.split("=").slice(1).join("=");
+    const ts = Date.parse(dateStr);
+    return Number.isFinite(ts) ? ts : undefined;
+  }
+  return undefined;
+}
+
+export class YApiAuthService {
+  private readonly baseUrl: string;
+  private readonly email: string;
+  private readonly password: string;
+  private readonly logger: Logger;
+  private readonly cache: YApiAuthCache;
+
+  constructor(baseUrl: string, email: string, password: string, logLevel: string = "info") {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.email = email;
+    this.password = password;
+    this.logger = new Logger("YApiAuthService", logLevel);
+    this.cache = new YApiAuthCache(this.baseUrl, logLevel);
+  }
+
+  loadCachedProjectTokens(): Map<string, string> {
+    return this.cache.loadProjectTokens();
+  }
+
+  private getCookieHeader(session: YApiSessionCookie): string {
+    const parts = [`_yapi_token=${session.yapiToken}`];
+    if (session.yapiUid) parts.push(`_yapi_uid=${session.yapiUid}`);
+    return parts.join("; ");
+  }
+
+  private isSessionValid(session: YApiSessionCookie | null): session is YApiSessionCookie {
+    if (!session?.yapiToken) return false;
+    if (!session.expiresAt) return true;
+    return Date.now() < session.expiresAt - 60_000; // 预留 1 分钟
+  }
+
+  async login(force: boolean = false): Promise<YApiSessionCookie> {
+    const cached = this.cache.loadSession();
+    if (!force && this.isSessionValid(cached)) return cached;
+
+    try {
+      this.logger.info("正在登录 YApi 以刷新全局 token...");
+      const response = await axios.post(
+        `${this.baseUrl}/api/user/login`,
+        { email: this.email, password: this.password },
+        { headers: { "Content-Type": "application/json;charset=UTF-8" } },
+      );
+
+      const setCookie = response.headers["set-cookie"] as string[] | undefined;
+      const yapiToken = pickCookieValue(setCookie, "_yapi_token");
+      const yapiUid = pickCookieValue(setCookie, "_yapi_uid");
+      const expiresAt = pickCookieExpiresAt(setCookie, "_yapi_token");
+
+      if (!yapiToken) {
+        const msg = (response.data as any)?.errmsg || "登录失败，未返回 _yapi_token";
+        throw new Error(msg);
+      }
+
+      const session: YApiSessionCookie = {
+        yapiToken,
+        yapiUid,
+        expiresAt,
+        updatedAt: Date.now(),
+      };
+      this.cache.saveSession(session);
+      return session;
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        throw new Error(error.response.data?.errmsg || "登录失败");
+      }
+      throw error instanceof Error ? error : new Error("登录失败");
+    }
+  }
+
+  private async cookieRequest<T>(
+    method: "GET" | "POST",
+    endpoint: string,
+    session: YApiSessionCookie,
+    options: { params?: JsonObject; data?: JsonObject } = {},
+  ): Promise<T> {
+    try {
+      const url = `${this.baseUrl}${endpoint}`;
+      const cookie = this.getCookieHeader(session);
+      const headers: Record<string, string> = { Cookie: cookie, Accept: "application/json, text/plain, */*" };
+      const res =
+        method === "GET"
+          ? await axios.get(url, { params: options.params, headers })
+          : await axios.post(url, options.data ?? {}, { params: options.params, headers });
+      return res.data as T;
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        throw new Error(error.response.data?.errmsg || "请求失败");
+      }
+      throw error instanceof Error ? error : new Error("请求失败");
+    }
+  }
+
+  private async listGroups(session: YApiSessionCookie): Promise<any[]> {
+    // 有些实例同时支持 group/get_mygroup 和 group/list，这里尽量都试一下并去重
+    const groups: any[] = [];
+    const tryFetch = async (endpoint: string) => {
+      try {
+        const res = await this.cookieRequest<any>("GET", endpoint, session);
+        if (res?.errcode === 0 && Array.isArray(res.data)) groups.push(...res.data);
+      } catch {
+        // ignore
+      }
+    };
+    await tryFetch("/api/group/get_mygroup");
+    await tryFetch("/api/group/list");
+
+    const seen = new Set<string>();
+    return groups.filter(g => {
+      const id = String(g?._id ?? g?.id ?? "");
+      if (!id || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }
+
+  private async listProjectsInGroup(session: YApiSessionCookie, groupId: string): Promise<any[]> {
+    const all: any[] = [];
+    const limit = 50;
+    let page = 1;
+    while (true) {
+      const res = await this.cookieRequest<any>("GET", "/api/project/list", session, {
+        params: { group_id: groupId, page, limit },
+      });
+      if (res?.errcode !== 0) break;
+      const list = res?.data?.list;
+      if (Array.isArray(list)) all.push(...list);
+      const total = Number(res?.data?.total ?? NaN);
+      if (!Number.isFinite(total)) {
+        if (!Array.isArray(list) || list.length < limit) break;
+      } else if (all.length >= total) {
+        break;
+      }
+      page += 1;
+      if (page > 200) break;
+    }
+    return all;
+  }
+
+  private async getProjectDetail(session: YApiSessionCookie, projectId: string): Promise<any> {
+    const res = await this.cookieRequest<any>("GET", "/api/project/get", session, { params: { id: projectId } });
+    if (res?.errcode !== 0) throw new Error(res?.errmsg || "获取项目详情失败");
+    return res.data;
+  }
+
+  async refreshProjectTokens(
+    options: { forceLogin?: boolean } = {},
+  ): Promise<{ tokens: Map<string, string>; projects: any[]; groups: any[] }> {
+    const session = await this.login(Boolean(options.forceLogin));
+    const groups = await this.listGroups(session);
+    const projects: any[] = [];
+
+    for (const g of groups) {
+      const groupId = String(g?._id ?? g?.id ?? "");
+      if (!groupId) continue;
+      try {
+        const list = await this.listProjectsInGroup(session, groupId);
+        projects.push(...list);
+      } catch (e) {
+        this.logger.warn(`获取分组项目列表失败(groupId=${groupId}): ${e}`);
+      }
+    }
+
+    const tokens = new Map<string, string>();
+    for (const p of projects) {
+      const projectId = String(p?._id ?? p?.id ?? "");
+      if (!projectId) continue;
+      try {
+        const detail = await this.getProjectDetail(session, projectId);
+        const token = String(detail?.token ?? "").trim();
+        if (token) tokens.set(projectId, token);
+      } catch (e) {
+        this.logger.warn(`获取项目 token 失败(projectId=${projectId}): ${e}`);
+      }
+    }
+
+    this.cache.saveProjectTokens(tokens);
+    return { tokens, projects, groups };
+  }
+}
+

--- a/src/services/yapi/authCache.ts
+++ b/src/services/yapi/authCache.ts
@@ -1,0 +1,111 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import crypto from "crypto";
+import { Logger } from "./logger";
+
+export interface YApiSessionCookie {
+  yapiToken: string;
+  yapiUid?: string;
+  expiresAt?: number; // ms since epoch
+  updatedAt: number; // ms since epoch
+}
+
+export interface YApiProjectTokenEntry {
+  token: string;
+  updatedAt: number; // ms since epoch
+}
+
+export interface YApiAuthCacheData {
+  version: 1;
+  baseUrl: string;
+  session?: YApiSessionCookie;
+  projectTokens: Record<string, YApiProjectTokenEntry>;
+}
+
+function hashBaseUrl(baseUrl: string): string {
+  return crypto.createHash("sha256").update(baseUrl).digest("hex").slice(0, 16);
+}
+
+export class YApiAuthCache {
+  private readonly logger: Logger;
+  private readonly baseUrl: string;
+  private readonly cacheDir: string;
+  private readonly cacheFilePath: string;
+
+  constructor(baseUrl: string, logLevel: string = "info") {
+    this.logger = new Logger("YApiAuthCache", logLevel);
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.cacheDir = path.join(os.homedir(), ".yapi-mcp");
+    this.cacheFilePath = path.join(this.cacheDir, `auth-${hashBaseUrl(this.baseUrl)}.json`);
+
+    if (!fs.existsSync(this.cacheDir)) {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+    }
+  }
+
+  load(): YApiAuthCacheData {
+    const empty: YApiAuthCacheData = {
+      version: 1,
+      baseUrl: this.baseUrl,
+      projectTokens: {},
+    };
+
+    try {
+      if (!fs.existsSync(this.cacheFilePath)) return empty;
+      const raw = fs.readFileSync(this.cacheFilePath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<YApiAuthCacheData>;
+      if (!parsed || parsed.version !== 1 || parsed.baseUrl !== this.baseUrl) return empty;
+      return {
+        version: 1,
+        baseUrl: this.baseUrl,
+        session: parsed.session,
+        projectTokens: parsed.projectTokens ?? {},
+      };
+    } catch (e) {
+      this.logger.warn(`读取全局鉴权缓存失败，将使用空缓存: ${e}`);
+      return empty;
+    }
+  }
+
+  save(data: YApiAuthCacheData): void {
+    try {
+      fs.writeFileSync(this.cacheFilePath, JSON.stringify(data, null, 2), "utf8");
+    } catch (e) {
+      this.logger.warn(`写入全局鉴权缓存失败: ${e}`);
+    }
+  }
+
+  loadSession(): YApiSessionCookie | null {
+    const data = this.load();
+    if (!data.session?.yapiToken) return null;
+    return data.session;
+  }
+
+  saveSession(session: YApiSessionCookie): void {
+    const data = this.load();
+    data.session = session;
+    this.save(data);
+  }
+
+  loadProjectTokens(): Map<string, string> {
+    const data = this.load();
+    const map = new Map<string, string>();
+    for (const [projectId, entry] of Object.entries(data.projectTokens ?? {})) {
+      if (entry?.token) map.set(projectId, entry.token);
+    }
+    return map;
+  }
+
+  saveProjectTokens(tokens: Map<string, string>): void {
+    const data = this.load();
+    const now = Date.now();
+    const obj: Record<string, YApiProjectTokenEntry> = {};
+    tokens.forEach((token, projectId) => {
+      obj[String(projectId)] = { token, updatedAt: now };
+    });
+    data.projectTokens = obj;
+    this.save(data);
+  }
+}
+

--- a/src/services/yapi/types.ts
+++ b/src/services/yapi/types.ts
@@ -5,6 +5,10 @@
 // 接口详细信息
 export interface ApiInterface {
   _id: string;
+  project_id?: number | string;
+  catid?: string;
+  status?: string;
+  tag?: string[];
   title: string;
   path: string;
   method: string;
@@ -14,10 +18,15 @@ export interface ApiInterface {
   req_query: any[];
   req_body_type: string;
   req_body_other: string;
+  req_body_is_json_schema?: boolean;
   res_body_type: string;
   res_body: string;
+  res_body_is_json_schema?: boolean;
+  switch_notice?: boolean;
+  api_opened?: boolean;
   desc: string;
   markdown: string;
+  message?: string;
   // 其他可能的字段...
 }
 
@@ -36,13 +45,16 @@ export interface SaveApiInterfaceParams {
   req_body_type?: string; // 请求体类型，如json, form, file等
   req_body_form?: any[]; // 表单请求体
   req_body_other?: string; // JSON或其他类型请求体
+  req_body_is_json_schema?: boolean; // 请求体是否为JSON Schema
   res_body_type?: string; // 响应体类型，如json, raw
   res_body?: string;     // 响应数据，通常是JSON Schema格式
+  res_body_is_json_schema?: boolean; // 响应数据是否为JSON Schema
   desc?: string;         // 接口描述
   markdown?: string;     // markdown格式的接口文档
   switch_notice?: boolean; // 是否开启通知
   api_opened?: boolean;  // 接口是否公开
   tag?: string[];        // 标签
+  status?: string;       // 接口状态
 }
 
 // 项目信息


### PR DESCRIPTION
- Fixes MCP tool schema/merge so AI updates structured fields (req_params/req_query/req_headers/req_body_*/res_body) instead of overusing desc
- Adds MCP tools for all endpoints documented in https://hellosean1025.github.io/yapi/openapi.html
- Aligns YApiService client with OpenAPI (form-urlencoded for /api/interface/add_cat and/api/open/import_data)
- Commits are split by: client changes, MCP tools/save behavior, README update.